### PR TITLE
Migrate runtime and tests to ES modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Root entry point for the OpenAgent CLI.
  *
@@ -14,12 +12,15 @@
  * - `src/commands`, `src/cli`, and `src/config` supply focused utilities that the loop depends upon.
  */
 
-require('dotenv').config();
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const { getOpenAIClient, resetOpenAIClient, MODEL } = require('./src/openai/client');
-const { startThinking, stopThinking, formatElapsedTime } = require('./src/cli/thinking');
-const { createInterface, askHuman } = require('./src/cli/io');
-const {
+import 'dotenv/config';
+
+import { getOpenAIClient, resetOpenAIClient, MODEL } from './src/openai/client.js';
+import { startThinking, stopThinking, formatElapsedTime } from './src/cli/thinking.js';
+import { createInterface, askHuman } from './src/cli/io.js';
+import {
   display,
   wrapStructuredContent,
   renderMarkdownMessage,
@@ -29,28 +30,28 @@ const {
   renderCommandResult,
   inferLanguageFromDetectors,
   detectLanguage,
-} = require('./src/cli/render');
-const { runCommand, runBrowse, runEdit, runRead, runReplace } = require('./src/commands/run');
-const {
+} from './src/cli/render.js';
+import { runCommand, runBrowse, runEdit, runRead, runReplace } from './src/commands/run.js';
+import {
   loadPreapprovedConfig,
   isPreapprovedCommand,
   isSessionApproved,
   approveForSession,
   resetSessionApprovals,
-  commandSignature: __commandSignature,
+  commandSignature as __commandSignature,
   PREAPPROVED_CFG,
-} = require('./src/commands/preapproval');
-const { applyFilter, tailLines, shellSplit } = require('./src/utils/text');
-const {
+} from './src/commands/preapproval.js';
+import { applyFilter, tailLines, shellSplit } from './src/utils/text.js';
+import {
   findAgentFiles,
   buildAgentsPrompt,
   BASE_SYSTEM_PROMPT,
   SYSTEM_PROMPT,
-} = require('./src/config/systemPrompt');
-const { createAgentLoop, extractResponseText } = require('./src/agent/loop');
-const { loadTemplates, renderTemplateCommand, handleTemplatesCli } = require('./src/templates/cli');
-const { loadShortcutsFile, findShortcut, handleShortcutsCli } = require('./src/shortcuts/cli');
-const { incrementCommandCount } = require('./src/commands/commandStats');
+} from './src/config/systemPrompt.js';
+import { createAgentLoop, extractResponseText } from './src/agent/loop.js';
+import { loadTemplates, renderTemplateCommand, handleTemplatesCli } from './src/templates/cli.js';
+import { loadShortcutsFile, findShortcut, handleShortcutsCli } from './src/shortcuts/cli.js';
+import { incrementCommandCount } from './src/commands/commandStats.js';
 
 let startupForceAutoApprove = process.argv.slice(2).some((arg) => {
   if (!arg) return false;
@@ -69,7 +70,7 @@ let startupNoHuman = process.argv.slice(2).some((arg) => {
   return normalized === 'nohuman' || normalized === '--nohuman' || normalized === '--no-human';
 });
 
-async function runCommandAndTrack(run, cwd = '.', timeoutSec = 60) {
+export async function runCommandAndTrack(run, cwd = '.', timeoutSec = 60) {
   const result = await runCommand(run, cwd, timeoutSec);
   try {
     let key = 'unknown';
@@ -95,7 +96,41 @@ function maybeHandleCliExtensions(argv = process.argv) {
   return false;
 }
 
-const exported = {
+async function runAgentLoopWithCurrentDependencies() {
+  const loop = createAgentLoop({
+    getAutoApproveFlag: () => exported.STARTUP_FORCE_AUTO_APPROVE,
+    getNoHumanFlag: () => exported.STARTUP_NO_HUMAN,
+    setNoHumanFlag: (value) => {
+      exported.STARTUP_NO_HUMAN = Boolean(value);
+    },
+    createInterfaceFn: exported.createInterface,
+    askHumanFn: exported.askHuman,
+    startThinkingFn: exported.startThinking,
+    stopThinkingFn: exported.stopThinking,
+    renderPlanFn: exported.renderPlan,
+    renderMessageFn: exported.renderMessage,
+    renderCommandFn: exported.renderCommand,
+    renderCommandResultFn: exported.renderCommandResult,
+    runCommandFn: exported.runCommand,
+    runBrowseFn: exported.runBrowse,
+    runEditFn: exported.runEdit,
+    runReadFn: exported.runRead,
+    runReplaceFn: exported.runReplace,
+    applyFilterFn: exported.applyFilter,
+    tailLinesFn: exported.tailLines,
+    isPreapprovedCommandFn: exported.isPreapprovedCommand,
+    isSessionApprovedFn: exported.isSessionApproved,
+    approveForSessionFn: exported.approveForSession,
+    preapprovedCfg: exported.PREAPPROVED_CFG,
+  });
+  return loop();
+}
+
+export async function agentLoop() {
+  return runAgentLoopWithCurrentDependencies();
+}
+
+export const exported = {
   get STARTUP_FORCE_AUTO_APPROVE() {
     return startupForceAutoApprove;
   },
@@ -152,52 +187,67 @@ const exported = {
   runCommandAndTrack,
   handleTemplatesCli,
   handleShortcutsCli,
+  agentLoop,
 };
 
-async function runAgentLoopWithCurrentDependencies() {
-  const loop = createAgentLoop({
-    getAutoApproveFlag: () => exported.STARTUP_FORCE_AUTO_APPROVE,
-    getNoHumanFlag: () => exported.STARTUP_NO_HUMAN,
-    setNoHumanFlag: (value) => {
-      exported.STARTUP_NO_HUMAN = Boolean(value);
-    },
-    createInterfaceFn: exported.createInterface,
-    askHumanFn: exported.askHuman,
-    startThinkingFn: exported.startThinking,
-    stopThinkingFn: exported.stopThinking,
-    renderPlanFn: exported.renderPlan,
-    renderMessageFn: exported.renderMessage,
-    renderCommandFn: exported.renderCommand,
-    renderCommandResultFn: exported.renderCommandResult,
-    runCommandFn: exported.runCommand,
-    runBrowseFn: exported.runBrowse,
-    runEditFn: exported.runEdit,
-    runReadFn: exported.runRead,
-    runReplaceFn: exported.runReplace,
-    applyFilterFn: exported.applyFilter,
-    tailLinesFn: exported.tailLines,
-    isPreapprovedCommandFn: exported.isPreapprovedCommand,
-    isSessionApprovedFn: exported.isSessionApproved,
-    approveForSessionFn: exported.approveForSession,
-    preapprovedCfg: exported.PREAPPROVED_CFG,
-  });
-  return loop();
-}
-
-exported.agentLoop = async function agentLoop() {
-  return runAgentLoopWithCurrentDependencies();
+export {
+  MODEL,
+  getOpenAIClient,
+  resetOpenAIClient,
+  startThinking,
+  stopThinking,
+  formatElapsedTime,
+  findAgentFiles,
+  buildAgentsPrompt,
+  BASE_SYSTEM_PROMPT,
+  SYSTEM_PROMPT,
+  runCommand,
+  runBrowse,
+  runEdit,
+  runRead,
+  runReplace,
+  applyFilter,
+  tailLines,
+  shellSplit,
+  display,
+  wrapStructuredContent,
+  renderMarkdownMessage,
+  renderPlan,
+  createInterface,
+  askHuman,
+  renderMessage,
+  renderCommand,
+  renderCommandResult,
+  inferLanguageFromDetectors,
+  detectLanguage,
+  loadPreapprovedConfig,
+  isPreapprovedCommand,
+  __commandSignature,
+  isSessionApproved,
+  approveForSession,
+  resetSessionApprovals,
+  extractResponseText,
+  PREAPPROVED_CFG,
+  loadTemplates,
+  renderTemplateCommand,
+  loadShortcutsFile,
+  findShortcut,
+  handleTemplatesCli,
+  handleShortcutsCli,
 };
 
-module.exports = exported;
+export default exported;
 
-if (require.main === module) {
+const currentFilePath = fileURLToPath(import.meta.url);
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath && currentFilePath === invokedPath) {
   const main = async () => {
     if (maybeHandleCliExtensions(process.argv)) {
       return;
     }
 
     try {
-      await exported.agentLoop();
+      await agentLoop();
     } catch (err) {
       if (err && err.message) {
         process.exitCode = 1;

--- a/legacy/index.cjs
+++ b/legacy/index.cjs
@@ -1,0 +1,209 @@
+'use strict';
+
+/**
+ * Root entry point for the OpenAgent CLI.
+ *
+ * Responsibilities:
+ * - Wire modular subsystems for OpenAI access, rendering, command execution, and approval flow.
+ * - Provide the aggregate export surface that tests exercise for individual helpers.
+ * - Dispatch template and shortcut subcommands before starting the interactive agent loop when run directly.
+ *
+ * Collaborators:
+ * - `src/agent/loop.js` drives the interactive conversation flow.
+ * - `src/openai/client.js` manages the memoized OpenAI client and model metadata.
+ * - `src/commands`, `src/cli`, and `src/config` supply focused utilities that the loop depends upon.
+ */
+
+require('dotenv').config();
+
+const { getOpenAIClient, resetOpenAIClient, MODEL } = require('./src/openai/client');
+const { startThinking, stopThinking, formatElapsedTime } = require('./src/cli/thinking');
+const { createInterface, askHuman } = require('./src/cli/io');
+const {
+  display,
+  wrapStructuredContent,
+  renderMarkdownMessage,
+  renderPlan,
+  renderMessage,
+  renderCommand,
+  renderCommandResult,
+  inferLanguageFromDetectors,
+  detectLanguage,
+} = require('./src/cli/render');
+const { runCommand, runBrowse, runEdit, runRead, runReplace } = require('./src/commands/run');
+const {
+  loadPreapprovedConfig,
+  isPreapprovedCommand,
+  isSessionApproved,
+  approveForSession,
+  resetSessionApprovals,
+  commandSignature: __commandSignature,
+  PREAPPROVED_CFG,
+} = require('./src/commands/preapproval');
+const { applyFilter, tailLines, shellSplit } = require('./src/utils/text');
+const {
+  findAgentFiles,
+  buildAgentsPrompt,
+  BASE_SYSTEM_PROMPT,
+  SYSTEM_PROMPT,
+} = require('./src/config/systemPrompt');
+const { createAgentLoop, extractResponseText } = require('./src/agent/loop');
+const { loadTemplates, renderTemplateCommand, handleTemplatesCli } = require('./src/templates/cli');
+const { loadShortcutsFile, findShortcut, handleShortcutsCli } = require('./src/shortcuts/cli');
+const { incrementCommandCount } = require('./src/commands/commandStats');
+
+let startupForceAutoApprove = process.argv.slice(2).some((arg) => {
+  if (!arg) return false;
+  const normalized = String(arg).trim().toLowerCase();
+  return (
+    normalized === 'auto' ||
+    normalized === '--auto' ||
+    normalized === '--auto-approve' ||
+    normalized === '--auto-approval'
+  );
+});
+
+let startupNoHuman = process.argv.slice(2).some((arg) => {
+  if (!arg) return false;
+  const normalized = String(arg).trim().toLowerCase();
+  return normalized === 'nohuman' || normalized === '--nohuman' || normalized === '--no-human';
+});
+
+async function runCommandAndTrack(run, cwd = '.', timeoutSec = 60) {
+  const result = await runCommand(run, cwd, timeoutSec);
+  try {
+    let key = 'unknown';
+    if (Array.isArray(run) && run.length > 0) key = String(run[0]);
+    else if (typeof run === 'string' && run.trim().length > 0) key = run.trim().split(/\s+/)[0];
+    await incrementCommandCount(key).catch(() => {});
+  } catch (err) {
+    // Ignore stats failures intentionally.
+  }
+  return result;
+}
+
+function maybeHandleCliExtensions(argv = process.argv) {
+  const mode = argv[2] || '';
+  if (mode === 'templates') {
+    handleTemplatesCli(argv);
+    return true;
+  }
+  if (mode === 'shortcuts') {
+    handleShortcutsCli(argv);
+    return true;
+  }
+  return false;
+}
+
+const exported = {
+  get STARTUP_FORCE_AUTO_APPROVE() {
+    return startupForceAutoApprove;
+  },
+  set STARTUP_FORCE_AUTO_APPROVE(value) {
+    startupForceAutoApprove = Boolean(value);
+  },
+  get STARTUP_NO_HUMAN() {
+    return startupNoHuman;
+  },
+  set STARTUP_NO_HUMAN(value) {
+    startupNoHuman = Boolean(value);
+  },
+  MODEL,
+  getOpenAIClient,
+  resetOpenAIClient,
+  startThinking,
+  stopThinking,
+  formatElapsedTime,
+  findAgentFiles,
+  buildAgentsPrompt,
+  BASE_SYSTEM_PROMPT,
+  SYSTEM_PROMPT,
+  runCommand,
+  runBrowse,
+  runEdit,
+  runRead,
+  runReplace,
+  applyFilter,
+  tailLines,
+  shellSplit,
+  display,
+  wrapStructuredContent,
+  renderMarkdownMessage,
+  renderPlan,
+  createInterface,
+  askHuman,
+  renderMessage,
+  renderCommand,
+  renderCommandResult,
+  inferLanguageFromDetectors,
+  detectLanguage,
+  loadPreapprovedConfig,
+  isPreapprovedCommand,
+  __commandSignature,
+  isSessionApproved,
+  approveForSession,
+  resetSessionApprovals,
+  extractResponseText,
+  PREAPPROVED_CFG,
+  loadTemplates,
+  renderTemplateCommand,
+  loadShortcutsFile,
+  findShortcut,
+  runCommandAndTrack,
+  handleTemplatesCli,
+  handleShortcutsCli,
+};
+
+async function runAgentLoopWithCurrentDependencies() {
+  const loop = createAgentLoop({
+    getAutoApproveFlag: () => exported.STARTUP_FORCE_AUTO_APPROVE,
+    getNoHumanFlag: () => exported.STARTUP_NO_HUMAN,
+    setNoHumanFlag: (value) => {
+      exported.STARTUP_NO_HUMAN = Boolean(value);
+    },
+    createInterfaceFn: exported.createInterface,
+    askHumanFn: exported.askHuman,
+    startThinkingFn: exported.startThinking,
+    stopThinkingFn: exported.stopThinking,
+    renderPlanFn: exported.renderPlan,
+    renderMessageFn: exported.renderMessage,
+    renderCommandFn: exported.renderCommand,
+    renderCommandResultFn: exported.renderCommandResult,
+    runCommandFn: exported.runCommand,
+    runBrowseFn: exported.runBrowse,
+    runEditFn: exported.runEdit,
+    runReadFn: exported.runRead,
+    runReplaceFn: exported.runReplace,
+    applyFilterFn: exported.applyFilter,
+    tailLinesFn: exported.tailLines,
+    isPreapprovedCommandFn: exported.isPreapprovedCommand,
+    isSessionApprovedFn: exported.isSessionApproved,
+    approveForSessionFn: exported.approveForSession,
+    preapprovedCfg: exported.PREAPPROVED_CFG,
+  });
+  return loop();
+}
+
+exported.agentLoop = async function agentLoop() {
+  return runAgentLoopWithCurrentDependencies();
+};
+
+module.exports = exported;
+
+if (require.main === module) {
+  const main = async () => {
+    if (maybeHandleCliExtensions(process.argv)) {
+      return;
+    }
+
+    try {
+      await exported.agentLoop();
+    } catch (err) {
+      if (err && err.message) {
+        process.exitCode = 1;
+      }
+    }
+  };
+
+  main();
+}

--- a/legacy/package.json
+++ b/legacy/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/legacy/src/agent/loop.js
+++ b/legacy/src/agent/loop.js
@@ -1,0 +1,597 @@
+'use strict';
+
+/**
+ * Implements the interactive agent loop that powers the CLI experience.
+ *
+ * Responsibilities:
+ * - Maintain the conversation history with OpenAI responses.
+ * - Render assistant output, prompt the human for approvals, and execute commands.
+ * - Feed execution results back to the model to continue the workflow.
+ *
+ * Consumers:
+ * - Root `index.js` creates a configured loop via `createAgentLoop()` and exposes it as `agentLoop`.
+ * - Integration tests re-export the same function to run mocked scenarios.
+ */
+
+const chalk = require('chalk');
+
+const { SYSTEM_PROMPT } = require('../config/systemPrompt');
+const { getOpenAIClient, MODEL } = require('../openai/client');
+const { startThinking, stopThinking } = require('../cli/thinking');
+const { createInterface, askHuman } = require('../cli/io');
+const { renderPlan, renderMessage, renderCommand, renderCommandResult } = require('../cli/render');
+const { runCommand, runBrowse, runEdit, runRead, runReplace } = require('../commands/run');
+const { applyFilter, tailLines, shellSplit } = require('../utils/text');
+const {
+  isPreapprovedCommand,
+  isSessionApproved,
+  approveForSession,
+  PREAPPROVED_CFG,
+} = require('../commands/preapproval');
+const { incrementCommandCount } = require('../commands/commandStats');
+const outputUtils = require('../utils/output');
+
+const NO_HUMAN_AUTO_MESSAGE = "continue or say 'done'";
+
+function extractResponseText(response) {
+  if (!response || typeof response !== 'object') {
+    return '';
+  }
+
+  if (typeof response.output_text === 'string') {
+    const normalized = response.output_text.trim();
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  const outputs = Array.isArray(response.output) ? response.output : [];
+  for (const item of outputs) {
+    if (!item || item.type !== 'message' || !Array.isArray(item.content)) {
+      continue;
+    }
+
+    for (const part of item.content) {
+      if (part && part.type === 'output_text' && typeof part.text === 'string') {
+        const normalized = part.text.trim();
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+  }
+
+  return '';
+}
+
+function parseReadSpecTokens(tokens) {
+  const spec = {};
+  const positional = [];
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (!token) {
+      continue;
+    }
+
+    if (token.startsWith('--')) {
+      const eqIndex = token.indexOf('=');
+      const rawKey = eqIndex !== -1 ? token.slice(2, eqIndex) : token.slice(2);
+      let value;
+      if (eqIndex !== -1) {
+        value = token.slice(eqIndex + 1);
+      } else if (i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
+        value = tokens[i + 1];
+        i += 1;
+      }
+
+      const key = rawKey.toLowerCase().replace(/-/g, '_');
+
+      if (key === 'encoding' && value) {
+        spec.encoding = value;
+      } else if (key === 'max_lines' && value) {
+        const parsed = parseInt(value, 10);
+        if (Number.isFinite(parsed)) {
+          spec.max_lines = parsed;
+        }
+      } else if (key === 'max_bytes' && value) {
+        const parsed = parseInt(value, 10);
+        if (Number.isFinite(parsed)) {
+          spec.max_bytes = parsed;
+        }
+      }
+
+      continue;
+    }
+
+    positional.push(token);
+  }
+
+  if (positional.length > 0) {
+    spec.path = positional[0];
+    if (positional.length > 1) {
+      spec.paths = positional.slice(1);
+    }
+  }
+
+  return spec;
+}
+
+function mergeReadSpecs(base, override) {
+  const merged = { ...base };
+
+  const orderedPaths = [];
+  const addPath = (candidate) => {
+    if (typeof candidate !== 'string') {
+      return;
+    }
+    const trimmed = candidate.trim();
+    if (!trimmed || orderedPaths.includes(trimmed)) {
+      return;
+    }
+    orderedPaths.push(trimmed);
+  };
+
+  const addPathsFromSpec = (spec) => {
+    if (!spec || typeof spec !== 'object') {
+      return;
+    }
+    if (typeof spec.path === 'string') {
+      addPath(spec.path);
+    }
+    if (Array.isArray(spec.paths)) {
+      for (const candidate of spec.paths) {
+        addPath(candidate);
+      }
+    }
+  };
+
+  addPathsFromSpec(base);
+  addPathsFromSpec(override);
+
+  if (orderedPaths.length > 0) {
+    merged.path = orderedPaths[0];
+    if (orderedPaths.length > 1) {
+      merged.paths = orderedPaths.slice(1);
+    } else {
+      delete merged.paths;
+    }
+  } else {
+    delete merged.path;
+    delete merged.paths;
+  }
+
+  if (override.encoding && merged.encoding === undefined) {
+    merged.encoding = override.encoding;
+  }
+
+  if (typeof override.max_lines === 'number' && merged.max_lines === undefined) {
+    merged.max_lines = override.max_lines;
+  }
+
+  if (typeof override.max_bytes === 'number' && merged.max_bytes === undefined) {
+    merged.max_bytes = override.max_bytes;
+  }
+
+  return merged;
+}
+
+async function executeAgentPass({
+  openai,
+  model,
+  history,
+  renderPlanFn,
+  renderMessageFn,
+  renderCommandFn,
+  renderCommandResultFn,
+  runCommandFn,
+  runBrowseFn,
+  runEditFn,
+  runReadFn,
+  runReplaceFn,
+  applyFilterFn,
+  tailLinesFn,
+  isPreapprovedCommandFn,
+  isSessionApprovedFn,
+  approveForSessionFn,
+  preapprovedCfg,
+  getAutoApproveFlag,
+  getNoHumanFlag,
+  setNoHumanFlag,
+  askHumanFn,
+  rl,
+  startThinkingFn,
+  stopThinkingFn,
+}) {
+  startThinkingFn();
+  console.log('Sending request to AI');
+  let completion;
+  try {
+    completion = await openai.responses.create({
+      model,
+      input: history,
+      text: {
+        format: { type: 'json_object' },
+      },
+    });
+  } finally {
+    stopThinkingFn();
+  }
+  console.log('Received response from AI');
+
+  const responseContent = extractResponseText(completion);
+
+  if (!responseContent) {
+    console.error(chalk.red('Error: OpenAI response did not include text output.'));
+    return false;
+  }
+
+  history.push({
+    role: 'assistant',
+    content: responseContent,
+  });
+
+  let parsed;
+  try {
+    parsed = JSON.parse(responseContent);
+  } catch (err) {
+    console.error(chalk.red('Error: LLM returned invalid JSON'));
+    console.error('Response:', responseContent);
+    return false;
+  }
+
+  //This is correct. AI message is just vanilla markdown.
+  renderMessageFn(parsed.message);
+  renderPlanFn(parsed.plan);
+
+  if (!parsed.command) {
+    if (
+      typeof getNoHumanFlag === 'function' &&
+      typeof setNoHumanFlag === 'function' &&
+      getNoHumanFlag()
+    ) {
+      const maybeMessage =
+        typeof parsed.message === 'string' ? parsed.message.trim().toLowerCase() : '';
+      const normalizedMessage = maybeMessage.replace(/[.!]+$/, '');
+      if (normalizedMessage === 'done') {
+        setNoHumanFlag(false);
+      }
+    }
+    return false;
+  }
+
+  renderCommandFn(parsed.command);
+
+  const autoApprovedAllowlist = isPreapprovedCommandFn(parsed.command, preapprovedCfg);
+  const autoApprovedSession = isSessionApprovedFn(parsed.command);
+  const autoApprovedCli = getAutoApproveFlag();
+  const autoApproved = autoApprovedAllowlist || autoApprovedSession || autoApprovedCli;
+
+  if (autoApproved) {
+    if (autoApprovedAllowlist) {
+      console.log(chalk.green('Auto-approved by allowlist (approved_commands.json)'));
+    } else if (autoApprovedSession) {
+      console.log(chalk.green('Auto-approved by session approvals'));
+    } else {
+      console.log(chalk.green('Auto-approved by CLI flag (--auto-approve)'));
+    }
+  } else {
+    let selection;
+    while (true) {
+      const input = (
+        await askHumanFn(
+          rl,
+          `
+Approve running this command?
+  1) Yes (run once)
+  2) Yes, for entire session (add to in-memory approvals)
+  3) No, tell the AI to do something else
+Select 1, 2, or 3: `,
+        )
+      )
+        .trim()
+        .toLowerCase();
+      if (input === '1' || input === 'y' || input === 'yes') {
+        selection = 1;
+        break;
+      }
+      if (input === '2') {
+        selection = 2;
+        break;
+      }
+      if (input === '3' || input === 'n' || input === 'no') {
+        selection = 3;
+        break;
+      }
+      console.log(chalk.yellow('Please enter 1, 2, or 3.'));
+    }
+
+    if (selection === 3) {
+      console.log(chalk.yellow('Command execution canceled by human (requested alternative).'));
+      const observation = {
+        observation_for_llm: {
+          canceled_by_human: true,
+          message:
+            'Human declined to execute the proposed command and asked the AI to propose an alternative approach without executing a command.',
+        },
+        observation_metadata: {
+          timestamp: new Date().toISOString(),
+        },
+      };
+      history.push({ role: 'user', content: JSON.stringify(observation) });
+      return true;
+    }
+    if (selection === 2) {
+      approveForSessionFn(parsed.command);
+      console.log(chalk.green('Approved and added to session approvals.'));
+    } else {
+      console.log(chalk.green('Approved (run once).'));
+    }
+  }
+
+  let result;
+  if (parsed.command && parsed.command.edit) {
+    result = await runEditFn(parsed.command.edit, parsed.command.cwd || '.');
+  }
+
+  if (typeof result === 'undefined' && parsed.command && parsed.command.read) {
+    result = await runReadFn(parsed.command.read, parsed.command.cwd || '.');
+  }
+
+  if (typeof result === 'undefined' && parsed.command && parsed.command.replace) {
+    result = await runReplaceFn(parsed.command.replace, parsed.command.cwd || '.');
+  }
+
+  if (typeof result === 'undefined') {
+    const runStrRaw = typeof parsed.command.run === 'string' ? parsed.command.run : '';
+    const runStr = runStrRaw.trim();
+
+    if (runStr) {
+      const tokens = shellSplit(runStr);
+      const commandKeyword = tokens[0] ? tokens[0].toLowerCase() : '';
+
+      if (commandKeyword === 'browse') {
+        const target = tokens.slice(1).join(' ').trim();
+        if (target) {
+          result = await runBrowseFn(target, parsed.command.timeout_sec ?? 60);
+        }
+      } else if (commandKeyword === 'read') {
+        const readTokens = tokens.slice(1);
+        const specFromTokens = parseReadSpecTokens(readTokens);
+        const mergedSpec = mergeReadSpecs(parsed.command.read || {}, specFromTokens);
+
+        if (mergedSpec.path) {
+          result = await runReadFn(mergedSpec, parsed.command.cwd || '.');
+        } else {
+          result = {
+            stdout: '',
+            stderr: 'read command requires a path argument',
+            exit_code: 1,
+            killed: false,
+            runtime_ms: 0,
+          };
+        }
+      }
+    }
+
+    if (typeof result === 'undefined') {
+      result = await runCommandFn(
+        parsed.command.run,
+        parsed.command.cwd || '.',
+        parsed.command.timeout_sec ?? 60,
+        parsed.command.shell,
+      );
+    }
+  }
+
+  let key = parsed?.command?.key;
+  if (!key) {
+    if (typeof parsed?.command?.run === 'string') {
+      key = parsed.command.run.trim().split(/\s+/)[0] || 'unknown';
+    } else {
+      key = 'unknown';
+    }
+  }
+  try {
+    await incrementCommandCount(key);
+  } catch (error) {
+    // Ignore stats failures intentionally.
+  }
+
+  let filteredStdout = result.stdout;
+  let filteredStderr = result.stderr;
+
+  const combined = outputUtils.combineStdStreams(
+    filteredStdout,
+    filteredStderr,
+    result.exit_code ?? 0,
+  );
+  filteredStdout = combined.stdout;
+  filteredStderr = combined.stderr;
+
+  if (parsed.command.filter_regex) {
+    filteredStdout = applyFilterFn(filteredStdout, parsed.command.filter_regex);
+    filteredStderr = applyFilterFn(filteredStderr, parsed.command.filter_regex);
+  }
+
+  if (parsed.command.tail_lines) {
+    filteredStdout = tailLinesFn(filteredStdout, parsed.command.tail_lines);
+    filteredStderr = tailLinesFn(filteredStderr, parsed.command.tail_lines);
+  }
+
+  const stdoutPreview = filteredStdout
+    ? filteredStdout.split('\n').slice(0, 20).join('\n') +
+      (filteredStdout.split('\n').length > 20 ? '\n…' : '')
+    : '';
+  const stderrPreview = filteredStderr
+    ? filteredStderr.split('\n').slice(0, 20).join('\n') +
+      (filteredStderr.split('\n').length > 20 ? '\n…' : '')
+    : '';
+
+  renderCommandResultFn(parsed.command, result, stdoutPreview, stderrPreview);
+
+  const observation = {
+    observation_for_llm: {
+      stdout: filteredStdout,
+      stderr: filteredStderr,
+      exit_code: result.exit_code,
+      truncated:
+        (parsed.command.filter_regex &&
+          (result.stdout !== filteredStdout || result.stderr !== filteredStderr)) ||
+        (parsed.command.tail_lines &&
+          (result.stdout.split('\n').length > parsed.command.tail_lines ||
+            result.stderr.split('\n').length > parsed.command.tail_lines)),
+    },
+    observation_metadata: {
+      runtime_ms: result.runtime_ms,
+      killed: result.killed,
+      timestamp: new Date().toISOString(),
+    },
+  };
+
+  history.push({
+    role: 'user',
+    content: JSON.stringify(observation),
+  });
+
+  return true;
+}
+
+function createAgentLoop({
+  systemPrompt = SYSTEM_PROMPT,
+  getClient = getOpenAIClient,
+  model = MODEL,
+  createInterfaceFn = createInterface,
+  askHumanFn = askHuman,
+  startThinkingFn = startThinking,
+  stopThinkingFn = stopThinking,
+  renderPlanFn = renderPlan,
+  renderMessageFn = renderMessage,
+  renderCommandFn = renderCommand,
+  renderCommandResultFn = renderCommandResult,
+  runCommandFn = runCommand,
+  runBrowseFn = runBrowse,
+  runEditFn = runEdit,
+  runReadFn = runRead,
+  runReplaceFn = runReplace,
+  applyFilterFn = applyFilter,
+  tailLinesFn = tailLines,
+  isPreapprovedCommandFn = isPreapprovedCommand,
+  isSessionApprovedFn = isSessionApproved,
+  approveForSessionFn = approveForSession,
+  preapprovedCfg = PREAPPROVED_CFG,
+  getAutoApproveFlag = () => false,
+  getNoHumanFlag = () => false,
+  setNoHumanFlag = () => {},
+} = {}) {
+  return async function agentLoop() {
+    const history = [
+      {
+        role: 'system',
+        content: systemPrompt,
+      },
+    ];
+
+    const rl = createInterfaceFn();
+
+    let openai;
+    try {
+      openai = getClient();
+    } catch (err) {
+      console.error('Error:', err.message);
+      console.error('Please create a .env file with your OpenAI API key.');
+      rl.close();
+      throw err;
+    }
+
+    console.log(chalk.bold.blue('\nOpenAgent - AI Agent with JSON Protocol'));
+    console.log(chalk.dim('Type "exit" or "quit" to end the conversation.'));
+    if (getAutoApproveFlag()) {
+      console.log(
+        chalk.yellow(
+          'Full auto-approval mode enabled via CLI flag. All commands will run without prompting.',
+        ),
+      );
+    }
+    if (getNoHumanFlag()) {
+      console.log(
+        chalk.yellow(
+          'No-human mode enabled (--nohuman). Agent will auto-respond with "continue or say \'done\'" until the AI replies "done".',
+        ),
+      );
+    }
+
+    try {
+      while (true) {
+        const noHumanActive = getNoHumanFlag();
+        const userInput = noHumanActive ? NO_HUMAN_AUTO_MESSAGE : await askHumanFn(rl, '\n ▷ ');
+
+        if (!userInput) {
+          if (noHumanActive) {
+            continue;
+          }
+          continue;
+        }
+
+        if (userInput.toLowerCase() === 'exit' || userInput.toLowerCase() === 'quit') {
+          console.log(chalk.green('Goodbye!'));
+          break;
+        }
+
+        history.push({
+          role: 'user',
+          content: userInput,
+        });
+
+        try {
+          let continueLoop = true;
+
+          while (continueLoop) {
+            const shouldContinue = await executeAgentPass({
+              openai,
+              model,
+              history,
+              renderPlanFn,
+              renderMessageFn,
+              renderCommandFn,
+              renderCommandResultFn,
+              runCommandFn,
+              runBrowseFn,
+              runEditFn,
+              runReadFn,
+              runReplaceFn,
+              applyFilterFn,
+              tailLinesFn,
+              isPreapprovedCommandFn,
+              isSessionApprovedFn,
+              approveForSessionFn,
+              preapprovedCfg,
+              getAutoApproveFlag,
+              getNoHumanFlag,
+              setNoHumanFlag,
+              askHumanFn,
+              rl,
+              startThinkingFn,
+              stopThinkingFn,
+            });
+
+            continueLoop = shouldContinue;
+          }
+        } catch (error) {
+          stopThinkingFn();
+          console.error(error);
+          if (error.response) {
+            console.error('Response:', error.response.data);
+          }
+        }
+      }
+    } finally {
+      rl.close();
+    }
+  };
+}
+
+module.exports = {
+  createAgentLoop,
+  extractResponseText,
+};

--- a/legacy/src/cli/io.js
+++ b/legacy/src/cli/io.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * Readline helpers that manage interactive user prompts.
+ *
+ * Responsibilities:
+ * - Expose a factory for the interactive readline interface used by the CLI.
+ * - Provide a convenience wrapper that highlights prompts in the terminal.
+ *
+ * Consumers:
+ * - `src/agent/loop.js` creates the interface and prompts users during command approvals.
+ * - Tests mock these helpers through the root index re-exports.
+ */
+
+const readline = require('readline');
+const chalk = require('chalk');
+
+function createInterface() {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: !!process.stdin.isTTY,
+  });
+}
+
+async function askHuman(rl, prompt) {
+  const answer = await new Promise((resolve) => {
+    rl.question(chalk.bold.blue(prompt), (response) => {
+      resolve(response);
+    });
+  });
+  return String(answer).trim();
+}
+
+module.exports = {
+  createInterface,
+  askHuman,
+};

--- a/legacy/src/cli/render.js
+++ b/legacy/src/cli/render.js
@@ -1,0 +1,207 @@
+'use strict';
+
+/**
+ * Terminal rendering helpers responsible for formatting assistant output.
+ *
+ * Responsibilities:
+ * - Provide a consistent boxed layout for messages, plans, and command details.
+ * - Wrap LLM output in Markdown and syntax-highlight structured content.
+ *
+ * Consumers:
+ * - `src/agent/loop.js` renders plans, messages, commands, and results using these helpers.
+ * - Root `index.js` re-exports the helpers for unit testing.
+ */
+
+const chalk = require('chalk');
+const { marked } = require('marked');
+const markedTerminal = require('marked-terminal');
+const TerminalRenderer = markedTerminal.default || markedTerminal;
+
+const terminalRenderer = new TerminalRenderer({
+  reflowText: false,
+  tab: 2,
+});
+
+function display(label, content, color = 'white') {
+  if (!content || (Array.isArray(content) && content.length === 0)) {
+    return;
+  }
+
+  const text = Array.isArray(content) ? content.join('\n') : String(content);
+  const borderColor = typeof color === 'string' ? color : 'white';
+  const chalkColorFn = chalk[borderColor] || chalk.white;
+  const header = `${label} ______________`;
+
+  console.log('');
+  console.log(chalkColorFn.bold(header));
+  console.log(text);
+}
+
+const COMMAND_READERS = ['sed', 'cat', 'read', 'edit'];
+const COMMAND_EXTENSION_MAPPINGS = [
+  { extensions: ['md', 'markdown'], language: 'markdown' },
+  { extensions: ['diff', 'patch'], language: 'diff' },
+  { extensions: ['py'], language: 'python' },
+  { extensions: ['js', 'jsx', 'mjs', 'cjs'], language: 'javascript' },
+  { extensions: ['json'], language: 'json' },
+  { extensions: ['html', 'htm'], language: 'html' },
+  { extensions: ['sh', 'bash'], language: 'bash' },
+];
+
+const COMMAND_DETECTORS = COMMAND_EXTENSION_MAPPINGS.map(({ extensions, language }) => {
+  const joinedExtensions = extensions.join('|');
+  const pattern = new RegExp(
+    String.raw`^\s*(?:${COMMAND_READERS.join('|')})\s+.*\.(${joinedExtensions})\b`,
+    'i',
+  );
+
+  return { pattern, language };
+});
+
+const CONTENT_TYPE_DETECTORS = [
+  { pattern: /(^|\n)diff --git /, language: 'diff' },
+  ...COMMAND_DETECTORS,
+  { pattern: /python3\s*-*\s*<<\s*['"]?PY['"]?/i, language: 'python' },
+  { pattern: /node\s*-*\s*<<\s*['"]?NODE['"]?/i, language: 'javascript' },
+  { pattern: /^\s*(\{[\s\S]*\}|\[[\s\S]*\])\s*$/, language: 'json' },
+  { pattern: /^\s*<[^>]+>/, language: 'html' },
+  { pattern: /^#!\s*.*python.*/i, language: 'python' },
+  { pattern: /^#!\s*.*(?:bash|sh).*/i, language: 'bash' },
+];
+
+function inferLanguageFromDetectors(content) {
+  for (const detector of CONTENT_TYPE_DETECTORS) {
+    if (detector.pattern.test(content)) {
+      return detector.language;
+    }
+  }
+
+  return null;
+}
+function wrapStructuredContent(message) {
+  if (!message) {
+    return '';
+  }
+
+  const trimmed = message.trim();
+
+  if (/```/.test(trimmed)) {
+    return trimmed;
+  }
+
+  const detectedLanguage = inferLanguageFromDetectors(trimmed);
+  if (detectedLanguage) {
+    return '```' + detectedLanguage + '\n' + trimmed + '\n```';
+  }
+
+  return trimmed;
+}
+function detectLanguage(content, fallbackLanguage = 'plaintext') {
+  if (!content) {
+    return fallbackLanguage;
+  }
+
+  const trimmed = content.trim();
+  const detected = inferLanguageFromDetectors(trimmed);
+
+  return detected || fallbackLanguage;
+}
+function wrapWithLanguageFence(text, language = 'plaintext') {
+  if (text === undefined || text === null) {
+    return '';
+  }
+
+  const content = String(text);
+  if (!content.trim() || /```/.test(content)) {
+    return content;
+  }
+
+  return `\`\`\`${language}\n${content}\n\`\`\``;
+}
+
+function renderMarkdownMessage(message) {
+  const prepared = wrapStructuredContent(message);
+  return marked.parse(prepared, { renderer: terminalRenderer });
+}
+
+function renderPlan(plan) {
+  if (!plan || !Array.isArray(plan) || plan.length === 0) return;
+
+  const planLines = plan.map((item) => {
+    const statusSymbol =
+      item.status === 'completed'
+        ? chalk.green('✔')
+        : item.status === 'running'
+          ? chalk.yellow('▶')
+          : chalk.gray('•');
+    const stepLabel = chalk.cyan(`Step ${item.step}`);
+    const title = chalk.white(item.title);
+    return `${statusSymbol} ${stepLabel} ${chalk.dim('-')} ${title}`;
+  });
+
+  display('Plan', planLines, 'cyan');
+}
+
+function renderMessage(message) {
+  if (!message) return;
+
+  const rendered = renderMarkdownMessage(message);
+  display('AI', rendered, 'magenta');
+}
+
+function renderCommand(command) {
+  if (!command) return;
+
+  const commandLines = [command.run];
+  //   `${chalk.cyan('Shell')}: ${command.shell || 'bash'}`,
+  //   `${chalk.cyan('Directory')}: ${command.cwd || '.'}`,
+  //   `${chalk.cyan('Timeout')}: ${command.timeout_sec ?? 60}s`,
+  // ];
+
+  // if (command.run) {
+  //   //this is correct, command should be bash/sh whatever shell we are running in
+  //   const fencedCommand = wrapWithLanguageFence(command.run, 'bash');
+  //   const renderedCommand = renderMarkdownMessage(fencedCommand);
+  //   commandLines.push('');
+  //   commandLines.push(renderedCommand);
+  // }
+
+  display('Command', commandLines, 'yellow');
+}
+
+function renderCommandResult(command, result, stdout, stderr) {
+  // const statusLines = [
+  //   `${chalk.cyan('Exit Code')}: ${result.exit_code}`,
+  //   `${chalk.cyan('Runtime')}: ${result.runtime_ms}ms`,
+  //   `${chalk.cyan('Status')}: ${result.killed ? chalk.red('KILLED (timeout)') : chalk.green('COMPLETED')}`,
+  // ];
+
+  // display('Command Result', statusLines, 'green');
+
+  const language = detectLanguage(command.command);
+
+  if (stdout) {
+    const fencedStdout = wrapWithLanguageFence(stdout, language);
+    const renderedStdout = renderMarkdownMessage(fencedStdout);
+    display('STDOUT', renderedStdout, 'white');
+  }
+
+  if (stderr) {
+    const fencedStderr = wrapWithLanguageFence(stderr, 'plaintext');
+    const renderedStderr = renderMarkdownMessage(fencedStderr);
+    display('STDERR', renderedStderr, 'red');
+  }
+}
+
+module.exports = {
+  display,
+  wrapStructuredContent,
+  renderMarkdownMessage,
+  renderPlan,
+  renderMessage,
+  renderCommand,
+  renderCommandResult,
+  wrapWithLanguageFence,
+  inferLanguageFromDetectors,
+  detectLanguage,
+};

--- a/legacy/src/cli/thinking.js
+++ b/legacy/src/cli/thinking.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Handles the lightweight CLI "thinking" animation shown while awaiting API calls.
+ *
+ * Responsibilities:
+ * - Render an animated status line with elapsed time.
+ * - Clear the animation once work completes.
+ *
+ * Consumers:
+ * - `src/agent/loop.js` invokes `startThinking()` before calling OpenAI and `stopThinking()` afterwards.
+ * - Tests rely on the root re-exports to stub these behaviours.
+ */
+
+const readline = require('readline');
+const chalk = require('chalk');
+
+let intervalHandle = null;
+let animationStart = null;
+
+function formatElapsedTime(startTime, now = Date.now()) {
+  if (!startTime || startTime > now) {
+    return '00:00';
+  }
+  const elapsedMs = Math.max(0, now - startTime);
+  const totalSeconds = Math.floor(elapsedMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return String(minutes).padStart(2, '0') + ':' + String(seconds).padStart(2, '0');
+}
+
+function startThinking() {
+  if (intervalHandle) return;
+  animationStart = Date.now();
+  const frames = ['Thinking.  ', 'Thinking.. ', 'Thinking...'];
+  let i = 0;
+  process.stdout.write('\n');
+  intervalHandle = setInterval(() => {
+    try {
+      const elapsed = formatElapsedTime(animationStart);
+      readline.clearLine(process.stdout, 0);
+      readline.cursorTo(process.stdout, 0);
+      process.stdout.write(chalk.dim(frames[i] + ' (' + elapsed + ')'));
+      i = (i + 1) % frames.length;
+    } catch (err) {
+      // Ignore TTY issues silently.
+    }
+  }, 400);
+}
+
+function stopThinking() {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+    animationStart = null;
+    try {
+      readline.clearLine(process.stdout, 0);
+      readline.cursorTo(process.stdout, 0);
+    } catch (err) {
+      // Ignore TTY issues silently.
+    }
+  }
+}
+
+module.exports = {
+  startThinking,
+  stopThinking,
+  formatElapsedTime,
+};

--- a/legacy/src/commands/browse.js
+++ b/legacy/src/commands/browse.js
@@ -1,0 +1,105 @@
+'use strict';
+
+async function runBrowse(url, timeoutSec) {
+  const startTime = Date.now();
+  let stdout = '';
+  let stderr = '';
+  let exit_code = 0;
+  let killed = false;
+
+  const buildResult = () => ({
+    stdout,
+    stderr,
+    exit_code,
+    killed,
+    runtime_ms: Date.now() - startTime,
+  });
+
+  try {
+    if (typeof fetch === 'function') {
+      const controller = new AbortController();
+      const timer = setTimeout(
+        () => {
+          controller.abort();
+          killed = true;
+        },
+        (timeoutSec ?? 60) * 1000,
+      );
+
+      try {
+        const res = await fetch(url, {
+          method: 'GET',
+          signal: controller.signal,
+          redirect: 'follow',
+        });
+        clearTimeout(timer);
+        stdout = await res.text();
+        if (!res.ok) {
+          stderr = `HTTP ${res.status} ${res.statusText}`;
+          exit_code = res.status || 1;
+        }
+      } catch (err) {
+        clearTimeout(timer);
+        stderr = err && err.message ? err.message : String(err);
+        exit_code = 1;
+      }
+
+      return buildResult();
+    }
+
+    const urlModule = require('url');
+    const http = require('http');
+    const https = require('https');
+    const parsed = urlModule.parse(url);
+    const lib = parsed.protocol === 'https:' ? https : http;
+
+    await new Promise((resolve) => {
+      const req = lib.request(
+        {
+          method: 'GET',
+          hostname: parsed.hostname,
+          port: parsed.port,
+          path: parsed.path,
+          headers: {},
+          timeout: (timeoutSec ?? 60) * 1000,
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (chunk) => chunks.push(chunk));
+          res.on('end', () => {
+            stdout = Buffer.concat(chunks).toString('utf8');
+            if (res.statusCode < 200 || res.statusCode >= 300) {
+              stderr = `HTTP ${res.statusCode}`;
+              exit_code = res.statusCode || 1;
+            }
+            resolve();
+          });
+        },
+      );
+
+      req.on('timeout', () => {
+        killed = true;
+        stderr = 'Request timed out';
+        exit_code = 1;
+        req.destroy(new Error('timeout'));
+        resolve();
+      });
+
+      req.on('error', (err) => {
+        stderr = err && err.message ? err.message : String(err);
+        exit_code = 1;
+        resolve();
+      });
+
+      req.end();
+    });
+
+    return buildResult();
+  } catch (err) {
+    stderr = err && err.message ? err.message : String(err);
+    exit_code = 1;
+    return buildResult();
+  }
+}
+
+module.exports = { runBrowse };

--- a/legacy/src/commands/commandStats.js
+++ b/legacy/src/commands/commandStats.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+const nodeCrypto = require('crypto');
+
+function resolveDefaultStatsPath() {
+  const xdgDataHome = process.env.XDG_DATA_HOME && process.env.XDG_DATA_HOME.trim();
+  if (xdgDataHome) {
+    return path.join(xdgDataHome, 'command-tracker', 'command-stats.json');
+  }
+
+  const homeDir = process.env.HOME || os.homedir();
+  if (homeDir) {
+    return path.join(homeDir, '.local', 'share', 'openagent', 'command-stats.json');
+  }
+
+  return path.resolve(__dirname, '../../command-stats.json');
+}
+
+const DEFAULT_STATS_PATH = resolveDefaultStatsPath();
+
+async function incrementCommandCount(cmdKey, logPath = null) {
+  try {
+    const targetPath = logPath ? path.resolve(logPath) : DEFAULT_STATS_PATH;
+    const dir = path.dirname(targetPath);
+    await fsp.mkdir(dir, { recursive: true });
+
+    let data = {};
+    try {
+      const raw = await fsp.readFile(targetPath, { encoding: 'utf8' });
+      data = JSON.parse(raw) || {};
+    } catch (err) {
+      data = {};
+    }
+
+    const existing = data[cmdKey];
+    let nextValue;
+    if (typeof existing === 'number' && Number.isFinite(existing)) {
+      nextValue = existing + 1;
+    } else {
+      const coerced = parseInt(existing, 10);
+      nextValue = Number.isFinite(coerced) ? coerced + 1 : 1;
+    }
+    data[cmdKey] = nextValue;
+
+    const randomSuffix = nodeCrypto.randomBytes(6).toString('hex');
+    const tempFile = path.join(dir, `._cmdstats_${Date.now()}_${randomSuffix}`);
+    let handle = null;
+    try {
+      handle = await fsp.open(tempFile, 'w');
+      await handle.writeFile(JSON.stringify(data), { encoding: 'utf8' });
+      await handle.sync();
+      await handle.close();
+      handle = null;
+      await fsp.rename(tempFile, targetPath);
+      return true;
+    } finally {
+      if (handle) {
+        await handle.close().catch(() => {});
+      }
+      await fsp.unlink(tempFile).catch(() => {});
+    }
+  } catch (err) {
+    return false;
+  }
+}
+
+module.exports = { incrementCommandCount };

--- a/legacy/src/commands/edit.js
+++ b/legacy/src/commands/edit.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function validateRange(text, start, end) {
+  if (!Number.isInteger(start) || !Number.isInteger(end)) {
+    throw new Error('start and end must be integers');
+  }
+  if (start < 0 || end < start || end > text.length) {
+    throw new Error('Invalid range');
+  }
+}
+
+function applyEdit(text, edit) {
+  if (!edit || typeof edit !== 'object') {
+    throw new Error('edit must be an object');
+  }
+  const { start, end, newText = '' } = edit;
+  validateRange(text, start, end);
+  return text.slice(0, start) + newText + text.slice(end);
+}
+
+function applyEdits(text, edits) {
+  if (!Array.isArray(edits)) {
+    throw new Error('edits must be an array');
+  }
+  const sorted = edits.slice().sort((a, b) => b.start - a.start);
+  return sorted.reduce((acc, edit) => applyEdit(acc, edit), text);
+}
+
+async function applyFileEdits(editSpec, cwd = '.') {
+  const start = Date.now();
+  try {
+    if (!editSpec || typeof editSpec !== 'object') {
+      throw new Error('editSpec must be an object');
+    }
+
+    const relPath = editSpec.path;
+    if (typeof relPath !== 'string' || relPath.trim() === '') {
+      throw new Error('editSpec.path must be a non-empty string');
+    }
+
+    const edits = editSpec.edits;
+    if (!Array.isArray(edits)) {
+      throw new Error('editSpec.edits must be an array');
+    }
+
+    const encoding = editSpec.encoding || 'utf8';
+    const absPath = path.resolve(cwd || '.', relPath);
+
+    let original;
+    try {
+      original = fs.readFileSync(absPath, { encoding });
+    } catch (err) {
+      throw new Error(`Unable to read file: ${absPath} — ${err.message}`);
+    }
+
+    const updated = applyEdits(original, edits);
+    fs.writeFileSync(absPath, updated, { encoding });
+
+    return {
+      stdout: `Edited ${path.relative(process.cwd(), absPath)}\n${updated}`,
+      stderr: '',
+      exit_code: 0,
+      killed: false,
+      runtime_ms: Date.now() - start,
+    };
+  } catch (err) {
+    return {
+      stdout: '',
+      stderr: err && err.message ? err.message : String(err),
+      exit_code: 1,
+      killed: false,
+      runtime_ms: Date.now() - start,
+    };
+  }
+}
+
+async function runEdit(editSpec, cwd = '.') {
+  return applyFileEdits(editSpec, cwd);
+}
+
+module.exports = {
+  applyEdit,
+  applyEdits,
+  applyFileEdits,
+  runEdit,
+};

--- a/legacy/src/commands/preapproval.js
+++ b/legacy/src/commands/preapproval.js
@@ -1,0 +1,192 @@
+'use strict';
+
+/**
+ * Implements the allowlist validation and in-memory approvals for command execution.
+ *
+ * Responsibilities:
+ * - Parse the approved command configuration from disk.
+ * - Determine whether a proposed command is auto-approved.
+ * - Track per-session approvals granted via the CLI prompt.
+ *
+ * Consumers:
+ * - `src/agent/loop.js` checks proposals against the allowlist and session approvals.
+ * - Unit tests exercise the individual helpers via root re-exports.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+
+const { shellSplit } = require('../utils/text');
+
+function loadPreapprovedConfig() {
+  const cfgPath = path.join(process.cwd(), 'approved_commands.json');
+  try {
+    if (fs.existsSync(cfgPath)) {
+      const raw = fs.readFileSync(cfgPath, 'utf8');
+      const parsed = JSON.parse(raw);
+      return parsed && parsed.allowlist ? parsed : { allowlist: [] };
+    }
+  } catch (err) {
+    console.error(chalk.yellow('Warning: Failed to load approved_commands.json:'), err.message);
+  }
+  return { allowlist: [] };
+}
+
+function isPreapprovedCommand(command, cfg) {
+  try {
+    const runRaw = (command && command.run ? String(command.run) : '').trim();
+    if (!runRaw) return false;
+
+    if (/\r|\n/.test(runRaw)) return false;
+
+    if (runRaw.toLowerCase().startsWith('browse ')) {
+      const url = runRaw.slice(7).trim();
+      if (!url || /\s/.test(url)) return false;
+      try {
+        const u = new URL(url);
+        if (u.protocol === 'http:' || u.protocol === 'https:') return true;
+      } catch (err) {
+        return false;
+      }
+      return false;
+    }
+
+    const forbidden = [/;|&&|\|\|/, /\|/, /`/, /\$\(/, /<\(/];
+    if (forbidden.some((re) => re.test(runRaw))) return false;
+
+    if (/^\s*sudo\b/.test(runRaw)) return false;
+    if (/(^|\s)[0-9]*>>?\s/.test(runRaw)) return false;
+    if (/\d?>&\d?/.test(runRaw)) return false;
+
+    const shellOpt = command && 'shell' in command ? command.shell : undefined;
+    if (typeof shellOpt === 'string') {
+      const normalized = String(shellOpt).trim().toLowerCase();
+      if (!['bash', 'sh'].includes(normalized)) return false;
+    }
+
+    const tokens = shellSplit(runRaw);
+    if (!tokens.length) return false;
+    const base = path.basename(tokens[0]);
+
+    const list = cfg && Array.isArray(cfg.allowlist) ? cfg.allowlist : [];
+    const entry = list.find((item) => item && item.name === base);
+    if (!entry) return false;
+
+    let sub = '';
+    for (let i = 1; i < tokens.length; i++) {
+      const token = tokens[i];
+      if (!token.startsWith('-')) {
+        sub = token;
+        break;
+      }
+    }
+
+    if (Array.isArray(entry.subcommands) && entry.subcommands.length > 0) {
+      if (!entry.subcommands.includes(sub)) return false;
+      if (['python', 'python3', 'pip', 'node', 'npm'].includes(base)) {
+        const afterIdx = tokens.indexOf(sub);
+        if (afterIdx !== -1 && tokens.length > afterIdx + 1) return false;
+      }
+    }
+
+    const joined = ' ' + tokens.slice(1).join(' ') + ' ';
+    switch (base) {
+      case 'sed':
+        if (/(^|\s)-i(\b|\s)/.test(joined)) return false;
+        break;
+      case 'find':
+        if (/\s-exec\b/.test(joined) || /\s-delete\b/.test(joined)) return false;
+        break;
+      case 'curl': {
+        if (/(^|\s)-X\s*(POST|PUT|PATCH|DELETE)\b/i.test(joined)) return false;
+        if (
+          /(^|\s)(--data(-binary|-raw|-urlencode)?|-d|--form|-F|--upload-file|-T)\b/i.test(joined)
+        )
+          return false;
+        if (/(^|\s)(-O|--remote-name|--remote-header-name)\b/.test(joined)) return false;
+        const tokensAfterBase = tokens.slice(1);
+        for (let i = 0; i < tokensAfterBase.length; i++) {
+          const token = tokensAfterBase[i];
+          if (token === '-o' || token === '--output') {
+            const name = tokensAfterBase[i + 1] || '';
+            if (name !== '-') return false;
+          }
+          if (token.startsWith('-o') && token.length > 2) return false;
+        }
+        break;
+      }
+      case 'wget': {
+        if (/\s--spider\b/.test(joined)) {
+          // allowed
+        } else {
+          const tokensAfterBase = tokens.slice(1);
+          for (let i = 0; i < tokensAfterBase.length; i++) {
+            const token = tokensAfterBase[i];
+            if (token === '-O' || token === '--output-document') {
+              const name = tokensAfterBase[i + 1] || '';
+              if (name !== '-') return false;
+            }
+            if (token.startsWith('-O') && token !== '-O') return false;
+          }
+        }
+        break;
+      }
+      case 'ping': {
+        const idx = tokens.indexOf('-c');
+        if (idx === -1) return false;
+        const count = parseInt(tokens[idx + 1], 10);
+        if (!Number.isFinite(count) || count > 3 || count < 1) return false;
+        break;
+      }
+      default:
+        break;
+    }
+
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+const sessionApprovals = new Set();
+
+function commandSignature(cmd) {
+  return JSON.stringify({
+    shell: cmd.shell || 'bash',
+    run: typeof cmd.run === 'string' ? cmd.run : '',
+    cwd: cmd.cwd || '.',
+  });
+}
+
+function isSessionApproved(cmd) {
+  try {
+    return sessionApprovals.has(commandSignature(cmd));
+  } catch (err) {
+    return false;
+  }
+}
+
+function approveForSession(cmd) {
+  try {
+    sessionApprovals.add(commandSignature(cmd));
+  } catch (err) {
+    // ignore
+  }
+}
+
+function resetSessionApprovals() {
+  sessionApprovals.clear();
+}
+
+const PREAPPROVED_CFG = loadPreapprovedConfig();
+
+module.exports = {
+  loadPreapprovedConfig,
+  isPreapprovedCommand,
+  isSessionApproved,
+  approveForSession,
+  resetSessionApprovals,
+  commandSignature,
+  PREAPPROVED_CFG,
+};

--- a/legacy/src/commands/read.js
+++ b/legacy/src/commands/read.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function normalizePaths(readSpec) {
+  const paths = [];
+  if (!readSpec || typeof readSpec !== 'object') {
+    return paths;
+  }
+
+  const seen = new Set();
+
+  const addPath = (relPath) => {
+    if (typeof relPath !== 'string') {
+      return;
+    }
+    const trimmed = relPath.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      return;
+    }
+    seen.add(trimmed);
+    paths.push(trimmed);
+  };
+
+  if (typeof readSpec.path === 'string') {
+    addPath(readSpec.path);
+  }
+
+  if (Array.isArray(readSpec.paths)) {
+    for (const candidate of readSpec.paths) {
+      addPath(candidate);
+    }
+  }
+
+  return paths;
+}
+
+async function runRead(readSpec, cwd = '.') {
+  const start = Date.now();
+  try {
+    if (!readSpec || typeof readSpec !== 'object') {
+      throw new Error('read spec must be an object');
+    }
+
+    const relPaths = normalizePaths(readSpec);
+    if (relPaths.length === 0) {
+      throw new Error('readSpec.path or readSpec.paths must include at least one path');
+    }
+
+    const encoding = readSpec.encoding || 'utf8';
+    const segments = [];
+
+    for (const relPath of relPaths) {
+      const absPath = path.resolve(cwd || '.', relPath);
+      let content = fs.readFileSync(absPath, { encoding });
+
+      if (typeof readSpec.max_bytes === 'number' && readSpec.max_bytes >= 0) {
+        const buffer = Buffer.from(content, encoding);
+        content = buffer.slice(0, readSpec.max_bytes).toString(encoding);
+      }
+
+      if (typeof readSpec.max_lines === 'number' && readSpec.max_lines >= 0) {
+        const lines = content.split('\n').slice(0, readSpec.max_lines);
+        content = lines.join('\n');
+      }
+
+      segments.push(`${relPath}:::\n${content}`);
+    }
+
+    return {
+      stdout: segments.join('\n'),
+      stderr: '',
+      exit_code: 0,
+      killed: false,
+      runtime_ms: Date.now() - start,
+    };
+  } catch (err) {
+    return {
+      stdout: '',
+      stderr: err && err.message ? err.message : String(err),
+      exit_code: 1,
+      killed: false,
+      runtime_ms: Date.now() - start,
+    };
+  }
+}
+
+module.exports = { runRead };

--- a/legacy/src/commands/replace.js
+++ b/legacy/src/commands/replace.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function normalizeFlags(flags) {
+  if (flags === undefined || flags === null) {
+    return 'g';
+  }
+  if (typeof flags !== 'string') {
+    throw new Error('flags must be a string');
+  }
+  const seen = new Set();
+  for (const char of flags) {
+    if (char && !seen.has(char)) {
+      seen.add(char);
+    }
+  }
+  if (!seen.has('g')) {
+    seen.add('g');
+  }
+  return Array.from(seen).join('');
+}
+
+function createRegex(pattern, flags) {
+  if (typeof pattern !== 'string' || pattern.trim() === '') {
+    throw new Error('pattern must be a non-empty string');
+  }
+
+  try {
+    return new RegExp(pattern, normalizeFlags(flags));
+  } catch (err) {
+    throw new Error(`Invalid regex pattern: ${err.message}`);
+  }
+}
+
+function validateFiles(files) {
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error('files must be a non-empty array of paths');
+  }
+
+  files.forEach((file, index) => {
+    if (typeof file !== 'string' || file.trim() === '') {
+      throw new Error(`files[${index}] must be a non-empty string`);
+    }
+  });
+}
+
+function buildResultSummary(results, dryRun) {
+  const totalMatches = results.reduce((acc, item) => acc + item.matches, 0);
+  const touchedFiles = results.filter((item) => item.matches > 0).length;
+
+  const lines = [`Total matches: ${totalMatches}`, `Files with changes: ${touchedFiles}`];
+
+  results.forEach((item) => {
+    lines.push(`${item.path}: ${item.matches} matches${dryRun ? ' (dry-run)' : ''}`);
+  });
+
+  if (dryRun) {
+    lines.push('Dry-run: no files were modified.');
+  }
+
+  return lines.join('\n');
+}
+
+function runReplace(spec, cwd = '.') {
+  const startTime = Date.now();
+  try {
+    if (!spec || typeof spec !== 'object') {
+      throw new Error('replace spec must be an object');
+    }
+
+    const { pattern, replacement = '', flags, files, encoding = 'utf8' } = spec;
+    const dryRun = spec.dry_run ?? spec.dryRun ?? false;
+
+    validateFiles(files);
+
+    const normalizedFlags = normalizeFlags(flags);
+    const regex = createRegex(pattern, normalizedFlags);
+
+    const results = [];
+
+    for (const relPath of files) {
+      const absPath = path.resolve(cwd || '.', relPath);
+      let original;
+      try {
+        original = fs.readFileSync(absPath, { encoding });
+      } catch (err) {
+        throw new Error(`Unable to read file: ${absPath} — ${err.message}`);
+      }
+
+      if (typeof original !== 'string') {
+        throw new Error(`File is not textual: ${absPath}`);
+      }
+
+      let matches = 0;
+      const replaced = original.replace(regex, (...args) => {
+        const match = args[0];
+        if (match === undefined) {
+          return args[0];
+        }
+        matches += 1;
+        return replacement;
+      });
+
+      if (!dryRun && matches > 0 && replaced !== original) {
+        try {
+          fs.writeFileSync(absPath, replaced, { encoding });
+        } catch (err) {
+          throw new Error(`Unable to write file: ${absPath} — ${err.message}`);
+        }
+      }
+
+      results.push({
+        path: path.relative(process.cwd(), absPath),
+        matches,
+      });
+    }
+
+    return {
+      stdout: buildResultSummary(results, dryRun),
+      stderr: '',
+      exit_code: 0,
+      killed: false,
+      runtime_ms: Date.now() - startTime,
+    };
+  } catch (err) {
+    return {
+      stdout: '',
+      stderr: err && err.message ? err.message : String(err),
+      exit_code: 1,
+      killed: false,
+      runtime_ms: Date.now() - startTime,
+    };
+  }
+}
+
+module.exports = {
+  runReplace,
+  _internal: {
+    normalizeFlags,
+    createRegex,
+  },
+};

--- a/legacy/src/commands/run.js
+++ b/legacy/src/commands/run.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Hosts the side-effecting primitives that execute shell commands and exposes
+ * higher-level helpers for browse, edit, and read operations.
+ *
+ * Responsibilities:
+ * - Launch child processes with timeout handling and capture their output streams.
+ * - Re-export the specialized helpers defined in their dedicated modules.
+ *
+ * Consumers:
+ * - `src/agent/loop.js` invokes these helpers while executing assistant generated commands.
+ * - Root `index.js` re-exports them for unit and integration tests.
+ */
+
+const { spawn } = require('child_process');
+const { runBrowse } = require('./browse');
+const { runEdit } = require('./edit');
+const { runRead } = require('./read');
+const { runReplace } = require('./replace');
+
+async function runCommand(cmd, cwd, timeoutSec, shellOpt) {
+  return new Promise((resolve) => {
+    const startTime = Date.now();
+    const proc = spawn(cmd, { cwd, shell: shellOpt ?? true });
+    let stdout = '';
+    let stderr = '';
+    let killed = false;
+
+    const timeout = setTimeout(() => {
+      proc.kill('SIGTERM');
+      killed = true;
+    }, timeoutSec * 1000);
+
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timeout);
+      resolve({
+        stdout,
+        stderr,
+        exit_code: code,
+        killed,
+        runtime_ms: Date.now() - startTime,
+      });
+    });
+  });
+}
+
+module.exports = {
+  runCommand,
+  runBrowse,
+  runEdit,
+  runRead,
+  runReplace,
+};

--- a/legacy/src/config/systemPrompt.js
+++ b/legacy/src/config/systemPrompt.js
@@ -1,0 +1,143 @@
+'use strict';
+
+/**
+ * Builds the system prompt that governs the agent runtime.
+ *
+ * Responsibilities:
+ * - Recursively discover local `AGENTS.md` guidance files.
+ * - Aggregate their contents and append them to the base system prompt.
+ *
+ * Consumers:
+ * - `src/agent/loop.js` reads `SYSTEM_PROMPT` to seed the conversation history.
+ * - Root `index.js` re-exports the discovery helpers for unit tests.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function findAgentFiles(rootDir) {
+  const discovered = [];
+
+  function walk(current) {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch (err) {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '.git') {
+        continue;
+      }
+
+      const fullPath = path.join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+
+      if (entry.isFile() && entry.name.toLowerCase() === 'agents.md') {
+        discovered.push(fullPath);
+      }
+    }
+  }
+
+  walk(rootDir);
+  return discovered;
+}
+
+function buildAgentsPrompt(rootDir) {
+  const agentFiles = findAgentFiles(rootDir);
+  if (agentFiles.length === 0) {
+    return '';
+  }
+
+  const sections = agentFiles
+    .map((filePath) => {
+      try {
+        const content = fs.readFileSync(filePath, 'utf8').trim();
+        if (!content) {
+          return '';
+        }
+        return `File: ${path.relative(rootDir, filePath)}\n${content}`;
+      } catch (err) {
+        return '';
+      }
+    })
+    .filter(Boolean);
+
+  if (sections.length === 0) {
+    return '';
+  }
+
+  return sections.join('\n\n---\n\n');
+}
+
+function readFileIfExists(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8').trim();
+    return content ? content : '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function buildBaseSystemPrompt(rootDir) {
+  const sections = [];
+
+  const promptFiles = [
+    path.join(rootDir, 'prompts', 'system.md'),
+    path.join(rootDir, 'prompts', 'developer.md'),
+  ];
+
+  for (const promptFile of promptFiles) {
+    const content = readFileIfExists(promptFile);
+    if (content) {
+      sections.push(content);
+    }
+  }
+
+  const brainDir = path.join(rootDir, 'brain');
+  let brainFiles = [];
+  try {
+    brainFiles = fs
+      .readdirSync(brainDir)
+      .filter((fileName) => fileName.toLowerCase().endsWith('.md'))
+      .sort();
+  } catch (err) {
+    brainFiles = [];
+  }
+
+  for (const fileName of brainFiles) {
+    const filePath = path.join(brainDir, fileName);
+    const content = readFileIfExists(filePath);
+    if (content) {
+      sections.push(content);
+    }
+  }
+
+  if (sections.length === 0) {
+    return 'You are an AI agent that helps users by executing commands and completing tasks.';
+  }
+
+  return sections.join('\n\n');
+}
+
+const BASE_SYSTEM_PROMPT = buildBaseSystemPrompt(process.cwd());
+
+const agentsGuidance = buildAgentsPrompt(process.cwd());
+
+const SYSTEM_PROMPT =
+  agentsGuidance.trim().length > 0
+    ? `${BASE_SYSTEM_PROMPT}\n\nThe following local operating rules are mandatory. They are sourced from AGENTS.md files present in the workspace:\n\n${agentsGuidance}`
+    : BASE_SYSTEM_PROMPT;
+
+module.exports = {
+  findAgentFiles,
+  buildAgentsPrompt,
+  buildBaseSystemPrompt,
+  BASE_SYSTEM_PROMPT,
+  SYSTEM_PROMPT,
+};

--- a/legacy/src/openai/client.js
+++ b/legacy/src/openai/client.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * OpenAI client factory shared across the CLI runtime.
+ *
+ * Responsibilities:
+ * - Lazily instantiate and memoize the OpenAI SDK client using environment variables.
+ * - Expose the current model identifier consumed by the agent loop.
+ *
+ * Consumers:
+ * - `src/agent/loop.js` obtains the memoized client through `getOpenAIClient()`.
+ * - Unit tests call `resetOpenAIClient()` via the root `index.js` re-export when they need a clean slate.
+ */
+
+const OpenAI = require('openai');
+
+let memoizedClient = null;
+
+function getOpenAIClient() {
+  if (!memoizedClient) {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error('OPENAI_API_KEY not found in environment variables.');
+    }
+    memoizedClient = new OpenAI({
+      apiKey,
+      baseURL: process.env.OPENAI_BASE_URL || undefined,
+    });
+  }
+  return memoizedClient;
+}
+
+function resetOpenAIClient() {
+  memoizedClient = null;
+}
+
+const MODEL = process.env.OPENAI_MODEL || process.env.OPENAI_CHAT_MODEL || 'gpt-5-codex';
+
+module.exports = {
+  getOpenAIClient,
+  resetOpenAIClient,
+  MODEL,
+};

--- a/legacy/src/shortcuts/cli.js
+++ b/legacy/src/shortcuts/cli.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * Shortcut CLI utilities mirroring the legacy behaviour from index.js.
+ *
+ * Responsibilities:
+ * - Read `shortcuts/shortcuts.json` and expose lookup helpers.
+ * - Handle the CLI entry points for listing, showing, or rendering shortcuts.
+ *
+ * Consumers:
+ * - Root `index.js` delegates to these helpers when launched with `shortcuts` arguments.
+ * - Integration tests rely on `loadShortcutsFile()` via the index re-export.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SHORTCUTS_PATH = path.join(process.cwd(), 'shortcuts', 'shortcuts.json');
+
+function loadShortcutsFile() {
+  try {
+    const raw = fs.readFileSync(SHORTCUTS_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch (err) {
+    return [];
+  }
+}
+
+function findShortcut(id) {
+  const list = loadShortcutsFile();
+  return list.find((s) => s.id === id);
+}
+
+function handleShortcutsCli(argv = process.argv) {
+  const sub = argv[3] || 'list';
+  const shortcuts = loadShortcutsFile();
+  if (sub === 'list') {
+    shortcuts.forEach((s) => console.log(`${s.id} - ${s.name}: ${s.description || ''}`));
+    process.exit(0);
+  }
+  if (sub === 'show') {
+    const id = argv[4];
+    const shortcut = shortcuts.find((x) => x.id === id);
+    if (!shortcut) {
+      console.error('Shortcut not found:', id);
+      process.exit(2);
+    }
+    console.log(JSON.stringify(shortcut, null, 2));
+    process.exit(0);
+  }
+  if (sub === 'run') {
+    const id = argv[4];
+    const shortcut = shortcuts.find((x) => x.id === id);
+    if (!shortcut) {
+      console.error('Shortcut not found:', id);
+      process.exit(2);
+    }
+    console.log(shortcut.command);
+    process.exit(0);
+  }
+
+  console.log('Usage: node index.js shortcuts [list|show <id>|run <id>]');
+  process.exit(0);
+}
+
+module.exports = {
+  loadShortcutsFile,
+  findShortcut,
+  handleShortcutsCli,
+};

--- a/legacy/src/templates/cli.js
+++ b/legacy/src/templates/cli.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/**
+ * Template CLI helpers for the agent entry point.
+ *
+ * Responsibilities:
+ * - Load command templates from `templates/command-templates.json`.
+ * - Render templates with provided variables when the CLI is executed in template mode.
+ *
+ * Consumers:
+ * - Root `index.js` delegates to `handleTemplatesCli()` when launched as `node index.js templates ...`.
+ * - Integration tests cover the JSON shape via the exported helpers.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TEMPLATES_PATH = path.join(process.cwd(), 'templates', 'command-templates.json');
+
+function loadTemplates() {
+  try {
+    const raw = fs.readFileSync(TEMPLATES_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch (err) {
+    return [];
+  }
+}
+
+function renderTemplateCommand(template, vars) {
+  let cmd = template.command || '';
+  const varsMap = Object.assign({}, vars || {});
+  (template.variables || []).forEach((variable) => {
+    if (!Object.prototype.hasOwnProperty.call(varsMap, variable.name)) {
+      varsMap[variable.name] = variable.default || '';
+    }
+  });
+
+  Object.keys(varsMap).forEach((key) => {
+    const re = new RegExp('{{\s*' + key + '\s*}}', 'g');
+    cmd = cmd.replace(re, String(varsMap[key]));
+  });
+  return cmd;
+}
+
+function handleTemplatesCli(argv = process.argv) {
+  const sub = argv[3] || 'list';
+  const templates = loadTemplates();
+  if (sub === 'list') {
+    templates.forEach((t) => console.log(`${t.id} - ${t.name}: ${t.description || ''}`));
+    process.exit(0);
+  }
+  if (sub === 'show') {
+    const id = argv[4];
+    const tmpl = templates.find((x) => x.id === id);
+    if (!tmpl) {
+      console.error('Template not found:', id);
+      process.exit(2);
+    }
+    console.log(JSON.stringify(tmpl, null, 2));
+    process.exit(0);
+  }
+  if (sub === 'render') {
+    const id = argv[4];
+    const varsJson = argv[5] || '{}';
+    let vars = {};
+    try {
+      vars = JSON.parse(varsJson);
+    } catch (err) {
+      console.error('Invalid JSON variables');
+      process.exit(3);
+    }
+    const tmpl = templates.find((x) => x.id === id);
+    if (!tmpl) {
+      console.error('Template not found:', id);
+      process.exit(2);
+    }
+    console.log(renderTemplateCommand(tmpl, vars));
+    process.exit(0);
+  }
+
+  console.log('Usage: node index.js templates [list|show <id>|render <id> <json-vars>]');
+  process.exit(0);
+}
+
+module.exports = {
+  loadTemplates,
+  renderTemplateCommand,
+  handleTemplatesCli,
+};

--- a/legacy/src/utils/output.js
+++ b/legacy/src/utils/output.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function combineStdStreams(filteredStdout, filteredStderr, exitCode) {
+  if (exitCode === 0 && filteredStderr && String(filteredStderr).trim().length > 0) {
+    const left = filteredStdout ? String(filteredStdout) : '';
+    const right = String(filteredStderr);
+    const combined = left ? `${left}\n${right}` : right;
+    return { stdout: combined, stderr: '' };
+  }
+  return { stdout: filteredStdout || '', stderr: filteredStderr || '' };
+}
+
+module.exports = { combineStdStreams };

--- a/legacy/src/utils/text.js
+++ b/legacy/src/utils/text.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * Text and shell utility helpers used across the agent runtime.
+ *
+ * Responsibilities:
+ * - Provide regex filtering and truncation helpers for command output.
+ * - Offer a minimal shell argument splitter reused by the pre-approval logic.
+ *
+ * Consumers:
+ * - `src/agent/loop.js` uses `applyFilter` and `tailLines` when preparing observations.
+ * - `src/commands/preapproval.js` depends on `shellSplit` to parse allow-listed commands.
+ */
+
+function applyFilter(text, regex) {
+  if (!regex) return text;
+  try {
+    const pattern = new RegExp(regex, 'i');
+    return text
+      .split('\n')
+      .filter((line) => pattern.test(line))
+      .join('\n');
+  } catch (err) {
+    console.error('Invalid regex pattern:', err.message);
+    return text;
+  }
+}
+
+function tailLines(text, lines) {
+  if (!lines) return text;
+  const allLines = text.split('\n');
+  return allLines.slice(-lines).join('\n');
+}
+
+function truncateOutput(text, { head = 200, tail = 200, snipMarker = '<snip....>' } = {}) {
+  if (text === undefined || text === null) {
+    return '';
+  }
+
+  const asString = String(text);
+  if (asString === '') {
+    return '';
+  }
+
+  const lines = asString.split('\n');
+  const totalLines = lines.length;
+
+  if (totalLines <= head + tail) {
+    return asString;
+  }
+
+  const tailSlice = tail > 0 ? lines.slice(-tail) : [];
+  const headSlice = head > 0 ? lines.slice(0, head) : [];
+
+  const parts = [];
+  if (tailSlice.length) {
+    parts.push(tailSlice.join('\n'));
+  }
+  parts.push(snipMarker);
+  if (headSlice.length) {
+    parts.push(headSlice.join('\n'));
+  }
+
+  return parts.join('\n');
+}
+
+function shellSplit(str) {
+  const re = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|\S+/g;
+  const out = [];
+  let match;
+  while ((match = re.exec(str))) {
+    out.push(match[1] ?? match[2] ?? match[0]);
+  }
+  return out;
+}
+
+module.exports = {
+  applyFilter,
+  tailLines,
+  truncateOutput,
+  shellSplit,
+};

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "openagent",
   "version": "1.0.0",
   "description": "Simple Node.JS based AI agent",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Simple Node.JS based AI agent",
   "type": "module",
   "main": "index.js",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "require": "./legacy/index.cjs"
+    },
+    "./legacy/*": "./legacy/*",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "start": "node index.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",

--- a/src/agent/loop.js
+++ b/src/agent/loop.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Implements the interactive agent loop that powers the CLI experience.
  *
@@ -13,27 +11,32 @@
  * - Integration tests re-export the same function to run mocked scenarios.
  */
 
-const chalk = require('chalk');
+import chalk from 'chalk';
 
-const { SYSTEM_PROMPT } = require('../config/systemPrompt');
-const { getOpenAIClient, MODEL } = require('../openai/client');
-const { startThinking, stopThinking } = require('../cli/thinking');
-const { createInterface, askHuman } = require('../cli/io');
-const { renderPlan, renderMessage, renderCommand, renderCommandResult } = require('../cli/render');
-const { runCommand, runBrowse, runEdit, runRead, runReplace } = require('../commands/run');
-const { applyFilter, tailLines, shellSplit } = require('../utils/text');
-const {
+import { SYSTEM_PROMPT } from '../config/systemPrompt.js';
+import { getOpenAIClient, MODEL } from '../openai/client.js';
+import { startThinking, stopThinking } from '../cli/thinking.js';
+import { createInterface, askHuman } from '../cli/io.js';
+import {
+  renderPlan,
+  renderMessage,
+  renderCommand,
+  renderCommandResult,
+} from '../cli/render.js';
+import { runCommand, runBrowse, runEdit, runRead, runReplace } from '../commands/run.js';
+import { applyFilter, tailLines, shellSplit } from '../utils/text.js';
+import {
   isPreapprovedCommand,
   isSessionApproved,
   approveForSession,
   PREAPPROVED_CFG,
-} = require('../commands/preapproval');
-const { incrementCommandCount } = require('../commands/commandStats');
-const outputUtils = require('../utils/output');
+} from '../commands/preapproval.js';
+import { incrementCommandCount } from '../commands/commandStats.js';
+import { combineStdStreams } from '../utils/output.js';
 
 const NO_HUMAN_AUTO_MESSAGE = "continue or say 'done'";
 
-function extractResponseText(response) {
+export function extractResponseText(response) {
   if (!response || typeof response !== 'object') {
     return '';
   }
@@ -240,7 +243,7 @@ async function executeAgentPass({
     return false;
   }
 
-  //This is correct. AI message is just vanilla markdown.
+  // This is correct. AI message is just vanilla markdown.
   renderMessageFn(parsed.message);
   renderPlanFn(parsed.plan);
 
@@ -281,12 +284,7 @@ async function executeAgentPass({
       const input = (
         await askHumanFn(
           rl,
-          `
-Approve running this command?
-  1) Yes (run once)
-  2) Yes, for entire session (add to in-memory approvals)
-  3) No, tell the AI to do something else
-Select 1, 2, or 3: `,
+          `Approve running this command?\n  1) Yes (run once)\n  2) Yes, for entire session (add to in-memory approvals)\n  3) No, tell the AI to do something else\nSelect 1, 2, or 3: `,
         )
       )
         .trim()
@@ -401,11 +399,7 @@ Select 1, 2, or 3: `,
   let filteredStdout = result.stdout;
   let filteredStderr = result.stderr;
 
-  const combined = outputUtils.combineStdStreams(
-    filteredStdout,
-    filteredStderr,
-    result.exit_code ?? 0,
-  );
+  const combined = combineStdStreams(filteredStdout, filteredStderr, result.exit_code ?? 0);
   filteredStdout = combined.stdout;
   filteredStderr = combined.stderr;
 
@@ -457,7 +451,7 @@ Select 1, 2, or 3: `,
   return true;
 }
 
-function createAgentLoop({
+export function createAgentLoop({
   systemPrompt = SYSTEM_PROMPT,
   getClient = getOpenAIClient,
   model = MODEL,
@@ -591,7 +585,7 @@ function createAgentLoop({
   };
 }
 
-module.exports = {
+export default {
   createAgentLoop,
   extractResponseText,
 };

--- a/src/cli/io.js
+++ b/src/cli/io.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Readline helpers that manage interactive user prompts.
  *
@@ -12,10 +10,10 @@
  * - Tests mock these helpers through the root index re-exports.
  */
 
-const readline = require('readline');
-const chalk = require('chalk');
+import readline from 'node:readline';
+import chalk from 'chalk';
 
-function createInterface() {
+export function createInterface() {
   return readline.createInterface({
     input: process.stdin,
     output: process.stdout,
@@ -23,7 +21,7 @@ function createInterface() {
   });
 }
 
-async function askHuman(rl, prompt) {
+export async function askHuman(rl, prompt) {
   const answer = await new Promise((resolve) => {
     rl.question(chalk.bold.blue(prompt), (response) => {
       resolve(response);
@@ -32,7 +30,7 @@ async function askHuman(rl, prompt) {
   return String(answer).trim();
 }
 
-module.exports = {
+export default {
   createInterface,
   askHuman,
 };

--- a/src/cli/render.js
+++ b/src/cli/render.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Terminal rendering helpers responsible for formatting assistant output.
  *
@@ -12,9 +10,10 @@
  * - Root `index.js` re-exports the helpers for unit testing.
  */
 
-const chalk = require('chalk');
-const { marked } = require('marked');
-const markedTerminal = require('marked-terminal');
+import chalk from 'chalk';
+import { marked } from 'marked';
+import markedTerminal from 'marked-terminal';
+
 const TerminalRenderer = markedTerminal.default || markedTerminal;
 
 const terminalRenderer = new TerminalRenderer({
@@ -22,7 +21,7 @@ const terminalRenderer = new TerminalRenderer({
   tab: 2,
 });
 
-function display(label, content, color = 'white') {
+export function display(label, content, color = 'white') {
   if (!content || (Array.isArray(content) && content.length === 0)) {
     return;
   }
@@ -69,7 +68,7 @@ const CONTENT_TYPE_DETECTORS = [
   { pattern: /^#!\s*.*(?:bash|sh).*/i, language: 'bash' },
 ];
 
-function inferLanguageFromDetectors(content) {
+export function inferLanguageFromDetectors(content) {
   for (const detector of CONTENT_TYPE_DETECTORS) {
     if (detector.pattern.test(content)) {
       return detector.language;
@@ -78,7 +77,8 @@ function inferLanguageFromDetectors(content) {
 
   return null;
 }
-function wrapStructuredContent(message) {
+
+export function wrapStructuredContent(message) {
   if (!message) {
     return '';
   }
@@ -96,7 +96,8 @@ function wrapStructuredContent(message) {
 
   return trimmed;
 }
-function detectLanguage(content, fallbackLanguage = 'plaintext') {
+
+export function detectLanguage(content, fallbackLanguage = 'plaintext') {
   if (!content) {
     return fallbackLanguage;
   }
@@ -106,7 +107,8 @@ function detectLanguage(content, fallbackLanguage = 'plaintext') {
 
   return detected || fallbackLanguage;
 }
-function wrapWithLanguageFence(text, language = 'plaintext') {
+
+export function wrapWithLanguageFence(text, language = 'plaintext') {
   if (text === undefined || text === null) {
     return '';
   }
@@ -119,12 +121,12 @@ function wrapWithLanguageFence(text, language = 'plaintext') {
   return `\`\`\`${language}\n${content}\n\`\`\``;
 }
 
-function renderMarkdownMessage(message) {
+export function renderMarkdownMessage(message) {
   const prepared = wrapStructuredContent(message);
   return marked.parse(prepared, { renderer: terminalRenderer });
 }
 
-function renderPlan(plan) {
+export function renderPlan(plan) {
   if (!plan || !Array.isArray(plan) || plan.length === 0) return;
 
   const planLines = plan.map((item) => {
@@ -142,42 +144,21 @@ function renderPlan(plan) {
   display('Plan', planLines, 'cyan');
 }
 
-function renderMessage(message) {
+export function renderMessage(message) {
   if (!message) return;
 
   const rendered = renderMarkdownMessage(message);
   display('AI', rendered, 'magenta');
 }
 
-function renderCommand(command) {
+export function renderCommand(command) {
   if (!command) return;
 
   const commandLines = [command.run];
-  //   `${chalk.cyan('Shell')}: ${command.shell || 'bash'}`,
-  //   `${chalk.cyan('Directory')}: ${command.cwd || '.'}`,
-  //   `${chalk.cyan('Timeout')}: ${command.timeout_sec ?? 60}s`,
-  // ];
-
-  // if (command.run) {
-  //   //this is correct, command should be bash/sh whatever shell we are running in
-  //   const fencedCommand = wrapWithLanguageFence(command.run, 'bash');
-  //   const renderedCommand = renderMarkdownMessage(fencedCommand);
-  //   commandLines.push('');
-  //   commandLines.push(renderedCommand);
-  // }
-
   display('Command', commandLines, 'yellow');
 }
 
-function renderCommandResult(command, result, stdout, stderr) {
-  // const statusLines = [
-  //   `${chalk.cyan('Exit Code')}: ${result.exit_code}`,
-  //   `${chalk.cyan('Runtime')}: ${result.runtime_ms}ms`,
-  //   `${chalk.cyan('Status')}: ${result.killed ? chalk.red('KILLED (timeout)') : chalk.green('COMPLETED')}`,
-  // ];
-
-  // display('Command Result', statusLines, 'green');
-
+export function renderCommandResult(command, result, stdout, stderr) {
   const language = detectLanguage(command.command);
 
   if (stdout) {
@@ -193,7 +174,7 @@ function renderCommandResult(command, result, stdout, stderr) {
   }
 }
 
-module.exports = {
+export default {
   display,
   wrapStructuredContent,
   renderMarkdownMessage,

--- a/src/cli/thinking.js
+++ b/src/cli/thinking.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Handles the lightweight CLI "thinking" animation shown while awaiting API calls.
  *
@@ -12,13 +10,13 @@
  * - Tests rely on the root re-exports to stub these behaviours.
  */
 
-const readline = require('readline');
-const chalk = require('chalk');
+import readline from 'node:readline';
+import chalk from 'chalk';
 
 let intervalHandle = null;
 let animationStart = null;
 
-function formatElapsedTime(startTime, now = Date.now()) {
+export function formatElapsedTime(startTime, now = Date.now()) {
   if (!startTime || startTime > now) {
     return '00:00';
   }
@@ -29,7 +27,7 @@ function formatElapsedTime(startTime, now = Date.now()) {
   return String(minutes).padStart(2, '0') + ':' + String(seconds).padStart(2, '0');
 }
 
-function startThinking() {
+export function startThinking() {
   if (intervalHandle) return;
   animationStart = Date.now();
   const frames = ['Thinking.  ', 'Thinking.. ', 'Thinking...'];
@@ -48,7 +46,7 @@ function startThinking() {
   }, 400);
 }
 
-function stopThinking() {
+export function stopThinking() {
   if (intervalHandle) {
     clearInterval(intervalHandle);
     intervalHandle = null;
@@ -62,7 +60,7 @@ function stopThinking() {
   }
 }
 
-module.exports = {
+export default {
   startThinking,
   stopThinking,
   formatElapsedTime,

--- a/src/commands/browse.js
+++ b/src/commands/browse.js
@@ -1,6 +1,7 @@
-'use strict';
+import http from 'node:http';
+import https from 'node:https';
 
-async function runBrowse(url, timeoutSec) {
+export async function runBrowse(url, timeoutSec) {
   const startTime = Date.now();
   let stdout = '';
   let stderr = '';
@@ -47,10 +48,7 @@ async function runBrowse(url, timeoutSec) {
       return buildResult();
     }
 
-    const urlModule = require('url');
-    const http = require('http');
-    const https = require('https');
-    const parsed = urlModule.parse(url);
+    const parsed = new URL(url);
     const lib = parsed.protocol === 'https:' ? https : http;
 
     await new Promise((resolve) => {
@@ -59,7 +57,7 @@ async function runBrowse(url, timeoutSec) {
           method: 'GET',
           hostname: parsed.hostname,
           port: parsed.port,
-          path: parsed.path,
+          path: `${parsed.pathname}${parsed.search}`,
           headers: {},
           timeout: (timeoutSec ?? 60) * 1000,
         },
@@ -102,4 +100,4 @@ async function runBrowse(url, timeoutSec) {
   }
 }
 
-module.exports = { runBrowse };
+export default { runBrowse };

--- a/src/commands/commandStats.js
+++ b/src/commands/commandStats.js
@@ -1,10 +1,11 @@
-'use strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import nodeCrypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 
-const fs = require('fs');
 const fsp = fs.promises;
-const path = require('path');
-const os = require('os');
-const nodeCrypto = require('crypto');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function resolveDefaultStatsPath() {
   const xdgDataHome = process.env.XDG_DATA_HOME && process.env.XDG_DATA_HOME.trim();
@@ -22,7 +23,7 @@ function resolveDefaultStatsPath() {
 
 const DEFAULT_STATS_PATH = resolveDefaultStatsPath();
 
-async function incrementCommandCount(cmdKey, logPath = null) {
+export async function incrementCommandCount(cmdKey, logPath = null) {
   try {
     const targetPath = logPath ? path.resolve(logPath) : DEFAULT_STATS_PATH;
     const dir = path.dirname(targetPath);
@@ -68,4 +69,4 @@ async function incrementCommandCount(cmdKey, logPath = null) {
   }
 }
 
-module.exports = { incrementCommandCount };
+export default { incrementCommandCount };

--- a/src/commands/edit.js
+++ b/src/commands/edit.js
@@ -1,9 +1,7 @@
-'use strict';
+import fs from 'node:fs';
+import path from 'node:path';
 
-const fs = require('fs');
-const path = require('path');
-
-function validateRange(text, start, end) {
+export function validateRange(text, start, end) {
   if (!Number.isInteger(start) || !Number.isInteger(end)) {
     throw new Error('start and end must be integers');
   }
@@ -12,7 +10,7 @@ function validateRange(text, start, end) {
   }
 }
 
-function applyEdit(text, edit) {
+export function applyEdit(text, edit) {
   if (!edit || typeof edit !== 'object') {
     throw new Error('edit must be an object');
   }
@@ -21,7 +19,7 @@ function applyEdit(text, edit) {
   return text.slice(0, start) + newText + text.slice(end);
 }
 
-function applyEdits(text, edits) {
+export function applyEdits(text, edits) {
   if (!Array.isArray(edits)) {
     throw new Error('edits must be an array');
   }
@@ -29,7 +27,7 @@ function applyEdits(text, edits) {
   return sorted.reduce((acc, edit) => applyEdit(acc, edit), text);
 }
 
-async function applyFileEdits(editSpec, cwd = '.') {
+export async function applyFileEdits(editSpec, cwd = '.') {
   const start = Date.now();
   try {
     if (!editSpec || typeof editSpec !== 'object') {
@@ -77,11 +75,11 @@ async function applyFileEdits(editSpec, cwd = '.') {
   }
 }
 
-async function runEdit(editSpec, cwd = '.') {
+export async function runEdit(editSpec, cwd = '.') {
   return applyFileEdits(editSpec, cwd);
 }
 
-module.exports = {
+export default {
   applyEdit,
   applyEdits,
   applyFileEdits,

--- a/src/commands/preapproval.js
+++ b/src/commands/preapproval.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Implements the allowlist validation and in-memory approvals for command execution.
  *
@@ -13,13 +11,13 @@
  * - Unit tests exercise the individual helpers via root re-exports.
  */
 
-const fs = require('fs');
-const path = require('path');
-const chalk = require('chalk');
+import fs from 'node:fs';
+import path from 'node:path';
+import chalk from 'chalk';
 
-const { shellSplit } = require('../utils/text');
+import { shellSplit } from '../utils/text.js';
 
-function loadPreapprovedConfig() {
+export function loadPreapprovedConfig() {
   const cfgPath = path.join(process.cwd(), 'approved_commands.json');
   try {
     if (fs.existsSync(cfgPath)) {
@@ -33,7 +31,7 @@ function loadPreapprovedConfig() {
   return { allowlist: [] };
 }
 
-function isPreapprovedCommand(command, cfg) {
+export function isPreapprovedCommand(command, cfg) {
   try {
     const runRaw = (command && command.run ? String(command.run) : '').trim();
     if (!runRaw) return false;
@@ -151,7 +149,7 @@ function isPreapprovedCommand(command, cfg) {
 
 const sessionApprovals = new Set();
 
-function commandSignature(cmd) {
+export function commandSignature(cmd) {
   return JSON.stringify({
     shell: cmd.shell || 'bash',
     run: typeof cmd.run === 'string' ? cmd.run : '',
@@ -159,7 +157,7 @@ function commandSignature(cmd) {
   });
 }
 
-function isSessionApproved(cmd) {
+export function isSessionApproved(cmd) {
   try {
     return sessionApprovals.has(commandSignature(cmd));
   } catch (err) {
@@ -167,7 +165,7 @@ function isSessionApproved(cmd) {
   }
 }
 
-function approveForSession(cmd) {
+export function approveForSession(cmd) {
   try {
     sessionApprovals.add(commandSignature(cmd));
   } catch (err) {
@@ -175,13 +173,13 @@ function approveForSession(cmd) {
   }
 }
 
-function resetSessionApprovals() {
+export function resetSessionApprovals() {
   sessionApprovals.clear();
 }
 
-const PREAPPROVED_CFG = loadPreapprovedConfig();
+export const PREAPPROVED_CFG = loadPreapprovedConfig();
 
-module.exports = {
+export default {
   loadPreapprovedConfig,
   isPreapprovedCommand,
   isSessionApproved,

--- a/src/commands/read.js
+++ b/src/commands/read.js
@@ -1,9 +1,7 @@
-'use strict';
+import fs from 'node:fs';
+import path from 'node:path';
 
-const fs = require('fs');
-const path = require('path');
-
-function normalizePaths(readSpec) {
+export function normalizePaths(readSpec) {
   const paths = [];
   if (!readSpec || typeof readSpec !== 'object') {
     return paths;
@@ -36,7 +34,7 @@ function normalizePaths(readSpec) {
   return paths;
 }
 
-async function runRead(readSpec, cwd = '.') {
+export async function runRead(readSpec, cwd = '.') {
   const start = Date.now();
   try {
     if (!readSpec || typeof readSpec !== 'object') {
@@ -86,4 +84,4 @@ async function runRead(readSpec, cwd = '.') {
   }
 }
 
-module.exports = { runRead };
+export default { runRead };

--- a/src/commands/replace.js
+++ b/src/commands/replace.js
@@ -1,9 +1,7 @@
-'use strict';
+import fs from 'node:fs';
+import path from 'node:path';
 
-const fs = require('fs');
-const path = require('path');
-
-function normalizeFlags(flags) {
+export function normalizeFlags(flags) {
   if (flags === undefined || flags === null) {
     return 'g';
   }
@@ -22,7 +20,7 @@ function normalizeFlags(flags) {
   return Array.from(seen).join('');
 }
 
-function createRegex(pattern, flags) {
+export function createRegex(pattern, flags) {
   if (typeof pattern !== 'string' || pattern.trim() === '') {
     throw new Error('pattern must be a non-empty string');
   }
@@ -63,7 +61,7 @@ function buildResultSummary(results, dryRun) {
   return lines.join('\n');
 }
 
-function runReplace(spec, cwd = '.') {
+export function runReplace(spec, cwd = '.') {
   const startTime = Date.now();
   try {
     if (!spec || typeof spec !== 'object') {
@@ -135,10 +133,12 @@ function runReplace(spec, cwd = '.') {
   }
 }
 
-module.exports = {
+export const _internal = {
+  normalizeFlags,
+  createRegex,
+};
+
+export default {
   runReplace,
-  _internal: {
-    normalizeFlags,
-    createRegex,
-  },
+  _internal,
 };

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Hosts the side-effecting primitives that execute shell commands and exposes
  * higher-level helpers for browse, edit, and read operations.
@@ -13,13 +11,14 @@
  * - Root `index.js` re-exports them for unit and integration tests.
  */
 
-const { spawn } = require('child_process');
-const { runBrowse } = require('./browse');
-const { runEdit } = require('./edit');
-const { runRead } = require('./read');
-const { runReplace } = require('./replace');
+import { spawn } from 'node:child_process';
 
-async function runCommand(cmd, cwd, timeoutSec, shellOpt) {
+import { runBrowse } from './browse.js';
+import { runEdit } from './edit.js';
+import { runRead } from './read.js';
+import { runReplace } from './replace.js';
+
+export async function runCommand(cmd, cwd, timeoutSec, shellOpt) {
   return new Promise((resolve) => {
     const startTime = Date.now();
     const proc = spawn(cmd, { cwd, shell: shellOpt ?? true });
@@ -53,7 +52,9 @@ async function runCommand(cmd, cwd, timeoutSec, shellOpt) {
   });
 }
 
-module.exports = {
+export { runBrowse, runEdit, runRead, runReplace };
+
+export default {
   runCommand,
   runBrowse,
   runEdit,

--- a/src/config/systemPrompt.js
+++ b/src/config/systemPrompt.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Builds the system prompt that governs the agent runtime.
  *
@@ -12,10 +10,10 @@
  * - Root `index.js` re-exports the discovery helpers for unit tests.
  */
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
 
-function findAgentFiles(rootDir) {
+export function findAgentFiles(rootDir) {
   const discovered = [];
 
   function walk(current) {
@@ -48,7 +46,7 @@ function findAgentFiles(rootDir) {
   return discovered;
 }
 
-function buildAgentsPrompt(rootDir) {
+export function buildAgentsPrompt(rootDir) {
   const agentFiles = findAgentFiles(rootDir);
   if (agentFiles.length === 0) {
     return '';
@@ -84,7 +82,7 @@ function readFileIfExists(filePath) {
   }
 }
 
-function buildBaseSystemPrompt(rootDir) {
+export function buildBaseSystemPrompt(rootDir) {
   const sections = [];
 
   const promptFiles = [
@@ -125,16 +123,16 @@ function buildBaseSystemPrompt(rootDir) {
   return sections.join('\n\n');
 }
 
-const BASE_SYSTEM_PROMPT = buildBaseSystemPrompt(process.cwd());
+export const BASE_SYSTEM_PROMPT = buildBaseSystemPrompt(process.cwd());
 
 const agentsGuidance = buildAgentsPrompt(process.cwd());
 
-const SYSTEM_PROMPT =
+export const SYSTEM_PROMPT =
   agentsGuidance.trim().length > 0
     ? `${BASE_SYSTEM_PROMPT}\n\nThe following local operating rules are mandatory. They are sourced from AGENTS.md files present in the workspace:\n\n${agentsGuidance}`
     : BASE_SYSTEM_PROMPT;
 
-module.exports = {
+export default {
   findAgentFiles,
   buildAgentsPrompt,
   buildBaseSystemPrompt,

--- a/src/openai/client.js
+++ b/src/openai/client.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * OpenAI client factory shared across the CLI runtime.
  *
@@ -12,11 +10,11 @@
  * - Unit tests call `resetOpenAIClient()` via the root `index.js` re-export when they need a clean slate.
  */
 
-const OpenAI = require('openai');
+import OpenAI from 'openai';
 
 let memoizedClient = null;
 
-function getOpenAIClient() {
+export function getOpenAIClient() {
   if (!memoizedClient) {
     const apiKey = process.env.OPENAI_API_KEY;
     if (!apiKey) {
@@ -30,13 +28,13 @@ function getOpenAIClient() {
   return memoizedClient;
 }
 
-function resetOpenAIClient() {
+export function resetOpenAIClient() {
   memoizedClient = null;
 }
 
-const MODEL = process.env.OPENAI_MODEL || process.env.OPENAI_CHAT_MODEL || 'gpt-5-codex';
+export const MODEL = process.env.OPENAI_MODEL || process.env.OPENAI_CHAT_MODEL || 'gpt-5-codex';
 
-module.exports = {
+export default {
   getOpenAIClient,
   resetOpenAIClient,
   MODEL,

--- a/src/shortcuts/cli.js
+++ b/src/shortcuts/cli.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Shortcut CLI utilities mirroring the legacy behaviour from index.js.
  *
@@ -12,12 +10,12 @@
  * - Integration tests rely on `loadShortcutsFile()` via the index re-export.
  */
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
 
 const SHORTCUTS_PATH = path.join(process.cwd(), 'shortcuts', 'shortcuts.json');
 
-function loadShortcutsFile() {
+export function loadShortcutsFile() {
   try {
     const raw = fs.readFileSync(SHORTCUTS_PATH, 'utf8');
     const parsed = JSON.parse(raw);
@@ -28,12 +26,12 @@ function loadShortcutsFile() {
   }
 }
 
-function findShortcut(id) {
+export function findShortcut(id) {
   const list = loadShortcutsFile();
   return list.find((s) => s.id === id);
 }
 
-function handleShortcutsCli(argv = process.argv) {
+export function handleShortcutsCli(argv = process.argv) {
   const sub = argv[3] || 'list';
   const shortcuts = loadShortcutsFile();
   if (sub === 'list') {
@@ -65,7 +63,7 @@ function handleShortcutsCli(argv = process.argv) {
   process.exit(0);
 }
 
-module.exports = {
+export default {
   loadShortcutsFile,
   findShortcut,
   handleShortcutsCli,

--- a/src/templates/cli.js
+++ b/src/templates/cli.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Template CLI helpers for the agent entry point.
  *
@@ -12,12 +10,12 @@
  * - Integration tests cover the JSON shape via the exported helpers.
  */
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
 
 const TEMPLATES_PATH = path.join(process.cwd(), 'templates', 'command-templates.json');
 
-function loadTemplates() {
+export function loadTemplates() {
   try {
     const raw = fs.readFileSync(TEMPLATES_PATH, 'utf8');
     const parsed = JSON.parse(raw);
@@ -28,7 +26,7 @@ function loadTemplates() {
   }
 }
 
-function renderTemplateCommand(template, vars) {
+export function renderTemplateCommand(template, vars) {
   let cmd = template.command || '';
   const varsMap = Object.assign({}, vars || {});
   (template.variables || []).forEach((variable) => {
@@ -44,7 +42,7 @@ function renderTemplateCommand(template, vars) {
   return cmd;
 }
 
-function handleTemplatesCli(argv = process.argv) {
+export function handleTemplatesCli(argv = process.argv) {
   const sub = argv[3] || 'list';
   const templates = loadTemplates();
   if (sub === 'list') {
@@ -84,7 +82,7 @@ function handleTemplatesCli(argv = process.argv) {
   process.exit(0);
 }
 
-module.exports = {
+export default {
   loadTemplates,
   renderTemplateCommand,
   handleTemplatesCli,

--- a/src/utils/output.js
+++ b/src/utils/output.js
@@ -1,6 +1,4 @@
-'use strict';
-
-function combineStdStreams(filteredStdout, filteredStderr, exitCode) {
+export function combineStdStreams(filteredStdout, filteredStderr, exitCode) {
   if (exitCode === 0 && filteredStderr && String(filteredStderr).trim().length > 0) {
     const left = filteredStdout ? String(filteredStdout) : '';
     const right = String(filteredStderr);
@@ -10,4 +8,4 @@ function combineStdStreams(filteredStdout, filteredStderr, exitCode) {
   return { stdout: filteredStdout || '', stderr: filteredStderr || '' };
 }
 
-module.exports = { combineStdStreams };
+export default { combineStdStreams };

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Text and shell utility helpers used across the agent runtime.
  *
@@ -12,7 +10,7 @@
  * - `src/commands/preapproval.js` depends on `shellSplit` to parse allow-listed commands.
  */
 
-function applyFilter(text, regex) {
+export function applyFilter(text, regex) {
   if (!regex) return text;
   try {
     const pattern = new RegExp(regex, 'i');
@@ -26,13 +24,13 @@ function applyFilter(text, regex) {
   }
 }
 
-function tailLines(text, lines) {
+export function tailLines(text, lines) {
   if (!lines) return text;
   const allLines = text.split('\n');
   return allLines.slice(-lines).join('\n');
 }
 
-function truncateOutput(text, { head = 200, tail = 200, snipMarker = '<snip....>' } = {}) {
+export function truncateOutput(text, { head = 200, tail = 200, snipMarker = '<snip....>' } = {}) {
   if (text === undefined || text === null) {
     return '';
   }
@@ -64,7 +62,7 @@ function truncateOutput(text, { head = 200, tail = 200, snipMarker = '<snip....>
   return parts.join('\n');
 }
 
-function shellSplit(str) {
+export function shellSplit(str) {
   const re = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|\S+/g;
   const out = [];
   let match;
@@ -74,7 +72,7 @@ function shellSplit(str) {
   return out;
 }
 
-module.exports = {
+export default {
   applyFilter,
   tailLines,
   truncateOutput,

--- a/tests/integration/cmdStats.integration.test.js
+++ b/tests/integration/cmdStats.integration.test.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 describe('runCommandAndTrack', () => {
   test('tracks command invocation counts', async () => {
@@ -9,7 +9,8 @@ describe('runCommandAndTrack', () => {
     process.env.XDG_DATA_HOME = tmpBase;
 
     try {
-      const index = require('../../index.js');
+      const indexModule = await import('../../index.js');
+      const index = indexModule.default;
       expect(typeof index.runCommandAndTrack).toBe('function');
 
       await index.runCommandAndTrack('node -v', process.cwd(), 30);

--- a/tests/integration/commandEdit.integration.test.js
+++ b/tests/integration/commandEdit.integration.test.js
@@ -1,7 +1,11 @@
-const fs = require('fs');
-const path = require('path');
-const { applyFileEdits } = require('../../src/commands/edit');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+import { applyFileEdits } from '../../src/commands/edit.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const TEST_FILE = path.resolve(__dirname, 'tmp_edit_test.txt');
 
 describe('applyFileEdits integration', () => {

--- a/tests/integration/shortcuts.integration.test.js
+++ b/tests/integration/shortcuts.integration.test.js
@@ -1,9 +1,10 @@
-const child = require('child_process');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 test('shortcuts file exists and has entries', () => {
   const p = path.join(process.cwd(), 'shortcuts', 'shortcuts.json');
-  const raw = require('fs').readFileSync(p, 'utf8');
+  const raw = fs.readFileSync(p, 'utf8');
   const arr = JSON.parse(raw);
   expect(Array.isArray(arr)).toBe(true);
   expect(arr.length).toBeGreaterThan(0);
@@ -11,11 +12,9 @@ test('shortcuts file exists and has entries', () => {
 
 test('run shortcut CLI prints command (tolerant of other CLI output)', () => {
   const node = process.execPath;
-  const out = child
-    .execFileSync(node, ['index.js', 'shortcuts', 'run', 'quick-tests'], {
-      encoding: 'utf8',
-      maxBuffer: 10 * 1024 * 1024,
-    })
-    .trim();
+  const out = execFileSync(node, ['index.js', 'shortcuts', 'run', 'quick-tests'], {
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  }).trim();
   expect(out).toMatch(/npm test/);
 });

--- a/tests/integration/templates.integration.test.js
+++ b/tests/integration/templates.integration.test.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const path = require('path');
-const child = require('child_process');
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 test('load templates file exists and is array', () => {
   const p = path.join(process.cwd(), 'templates', 'command-templates.json');
@@ -13,10 +13,8 @@ test('load templates file exists and is array', () => {
 test('render template via CLI', () => {
   const node = process.execPath;
   const vars = JSON.stringify({ package: 'lodash' });
-  const out = child
-    .execFileSync(node, ['index.js', 'templates', 'render', 'install-deps', vars], {
-      encoding: 'utf8',
-    })
-    .trim();
+  const out = execFileSync(node, ['index.js', 'templates', 'render', 'install-deps', vars], {
+    encoding: 'utf8',
+  }).trim();
   expect(out).toContain('npm install');
 });

--- a/tests/mockOpenAI.js
+++ b/tests/mockOpenAI.js
@@ -1,14 +1,13 @@
 // Preload mock for 'openai' module so the agent uses our stubbed client
-const Module = require('module');
+import Module from 'node:module';
+
 const originalLoad = Module._load;
-Module._load = function (request, _parent, _isMain) {
+Module._load = function (request, parent, isMain) {
   if (request === 'openai') {
-    // Return a constructor function compatible with `new OpenAI({ apiKey, baseURL })`
     return function OpenAIMock(_options) {
       return {
         responses: {
-          create: async function (_opts) {
-            // Simulate a single assistant response that instructs running a harmless command
+          create: async function () {
             const payload = {
               output: [
                 {
@@ -37,5 +36,5 @@ Module._load = function (request, _parent, _isMain) {
       };
     };
   }
-  return originalLoad.apply(this, arguments);
+  return originalLoad.apply(this, [request, parent, isMain]);
 };

--- a/tests/unit/agentBuiltins.test.js
+++ b/tests/unit/agentBuiltins.test.js
@@ -1,4 +1,6 @@
-const { createAgentLoop } = require('../../src/agent/loop');
+import { jest } from '@jest/globals';
+
+import { createAgentLoop } from '../../src/agent/loop.js';
 
 function buildResponsePayload(payload) {
   return Promise.resolve({

--- a/tests/unit/editText.test.js
+++ b/tests/unit/editText.test.js
@@ -1,4 +1,4 @@
-const { applyEdit, applyEdits } = require('../../src/commands/edit');
+import { applyEdit, applyEdits } from '../../src/commands/edit.js';
 
 describe('applyEdit', () => {
   test('inserts text at position when start === end', () => {

--- a/tests/unit/legacyInterop.test.js
+++ b/tests/unit/legacyInterop.test.js
@@ -1,0 +1,43 @@
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const testFilePath = fileURLToPath(import.meta.url);
+const projectRoot = path.resolve(testFilePath, '../../..');
+const localRequire = createRequire(import.meta.url);
+
+describe('CommonJS compatibility layer', () => {
+  test('legacy entry exposes expected surface', () => {
+    const legacy = localRequire('../../legacy/index.cjs');
+
+    expect(typeof legacy.agentLoop).toBe('function');
+    expect(typeof legacy.runCommandAndTrack).toBe('function');
+    expect(typeof legacy.runCommand).toBe('function');
+    expect(typeof legacy.STARTUP_FORCE_AUTO_APPROVE).toBe('boolean');
+    expect(legacy.PREAPPROVED_CFG).toBeDefined();
+  });
+
+  test('package consumers can require openagent', () => {
+    const script = `
+      const mod = require('openagent');
+      console.log(JSON.stringify({
+        hasLoop: typeof mod.agentLoop === 'function',
+        hasTracker: typeof mod.runCommandAndTrack === 'function'
+      }));
+    `;
+
+    const result = spawnSync(process.execPath, ['-e', script], {
+      env: { ...process.env, NODE_PATH: projectRoot },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    const outputLines = result.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const payload = JSON.parse(outputLines[outputLines.length - 1]);
+    expect(payload).toEqual({ hasLoop: true, hasTracker: true });
+  });
+});

--- a/tests/unit/outputUtils.test.js
+++ b/tests/unit/outputUtils.test.js
@@ -1,4 +1,4 @@
-const { combineStdStreams } = require('../../src/utils/output');
+import { combineStdStreams } from '../../src/utils/output.js';
 
 describe('combineStdStreams', () => {
   test('concats stderr into stdout on success (exitCode 0)', () => {

--- a/tests/unit/renderLanguage.test.js
+++ b/tests/unit/renderLanguage.test.js
@@ -1,10 +1,13 @@
+import { jest } from '@jest/globals';
+
 const defaultEnv = { ...process.env };
 
-function loadModule() {
+async function loadModule() {
   jest.resetModules();
   process.env = { ...defaultEnv };
-  jest.doMock('dotenv', () => ({ config: jest.fn() }));
-  return require('../../index.js');
+  jest.unstable_mockModule('dotenv/config', () => ({}));
+  const imported = await import('../../index.js');
+  return imported.default;
 }
 
 afterEach(() => {
@@ -14,50 +17,50 @@ afterEach(() => {
 });
 
 describe('inferLanguageFromDetectors', () => {
-  test('detects git diff content', () => {
-    const mod = loadModule();
+  test('detects git diff content', async () => {
+    const mod = await loadModule();
     expect(mod.inferLanguageFromDetectors('diff --git a/file b/file')).toBe('diff');
   });
 
-  test('detects language from command extensions', () => {
-    const mod = loadModule();
+  test('detects language from command extensions', async () => {
+    const mod = await loadModule();
     expect(mod.inferLanguageFromDetectors('cat scripts/example.py')).toBe('python');
     expect(mod.inferLanguageFromDetectors('read ./deploy.sh')).toBe('bash');
   });
 
-  test('detects python heredoc blocks', () => {
-    const mod = loadModule();
-    const heredoc = ["python3 <<'PY'", "print('hi')", 'PY'].join('\\n');
+  test('detects python heredoc blocks', async () => {
+    const mod = await loadModule();
+    const heredoc = ["python3 <<'PY'", "print('hi')", 'PY'].join('\n');
     expect(mod.inferLanguageFromDetectors(heredoc)).toBe('python');
   });
 
-  test('detects json structures', () => {
-    const mod = loadModule();
+  test('detects json structures', async () => {
+    const mod = await loadModule();
     expect(mod.inferLanguageFromDetectors('{"foo": 1}')).toBe('json');
     expect(mod.inferLanguageFromDetectors('[1, 2, 3]')).toBe('json');
   });
 
-  test('detects html snippets and shebangs', () => {
-    const mod = loadModule();
+  test('detects html snippets and shebangs', async () => {
+    const mod = await loadModule();
     expect(mod.inferLanguageFromDetectors('<div>Hello</div>')).toBe('html');
     expect(mod.inferLanguageFromDetectors('#!/usr/bin/env python3')).toBe('python');
     expect(mod.inferLanguageFromDetectors('#!/bin/bash')).toBe('bash');
   });
 
-  test('returns null when detectors do not match', () => {
-    const mod = loadModule();
+  test('returns null when detectors do not match', async () => {
+    const mod = await loadModule();
     expect(mod.inferLanguageFromDetectors('plain text without hints')).toBeNull();
   });
 });
 
 describe('detectLanguage', () => {
-  test('prefers detected language over fallback', () => {
-    const mod = loadModule();
+  test('prefers detected language over fallback', async () => {
+    const mod = await loadModule();
     expect(mod.detectLanguage('diff --git a/file b/file', 'plaintext')).toBe('diff');
   });
 
-  test('returns fallback when detectors fail', () => {
-    const mod = loadModule();
+  test('returns fallback when detectors fail', async () => {
+    const mod = await loadModule();
     expect(mod.detectLanguage('plain text', 'plaintext')).toBe('plaintext');
     expect(mod.detectLanguage('', 'markdown')).toBe('markdown');
   });

--- a/tests/unit/replaceCommand.test.js
+++ b/tests/unit/replaceCommand.test.js
@@ -1,8 +1,8 @@
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
-const { runReplace } = require('../../src/commands/replace');
+import { runReplace } from '../../src/commands/replace.js';
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));


### PR DESCRIPTION
## Summary
- convert the project to ES modules by updating package metadata and the CLI entry point
- migrate the agent, command, and helper modules to native import/export semantics
- update integration and unit tests to mock ES modules and run under the experimental VM modules flag

## Testing
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e243576b988328b746dc380951a8c4