### PR TITLE
Refactor Jest OpenAI mock for ESM

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/tests/mockOpenAI.js'],
+};

--- a/tests/context.md
+++ b/tests/context.md
@@ -7,7 +7,7 @@
 ## Structure
 - `integration/`: high-level tests exercising the agent loop, command runners, and CLI wrappers.
 - `unit/`: focused tests for utilities, command helpers, rendering logic, etc.
-- `mockOpenAI.js`: global mocking hook for the `openai` package during integration runs.
+- `mockOpenAI.js`: Jest setup module that pre-registers the default `openai` mock for every suite.
 
 ## Positive Signals
 - Integration tests validate agent loop approvals, read command dispatch, command stats persistence, and CLI wrappers for templates/shortcuts.

--- a/tests/mockOpenAI.js
+++ b/tests/mockOpenAI.js
@@ -1,40 +1,111 @@
-// Preload mock for 'openai' module so the agent uses our stubbed client
-import * as nodeModule from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, jest } from '@jest/globals';
 
-const originalLoad = nodeModule._load;
-nodeModule._load = function (request, parent, isMain) {
-  if (request === 'openai') {
-    return function OpenAIMock(_options) {
-      return {
-        responses: {
-          create: async function () {
-            const payload = {
-              output: [
-                {
-                  type: 'message',
-                  content: [
-                    {
-                      type: 'output_text',
-                      text: JSON.stringify({
-                        message: 'Mocked response',
-                        plan: [],
-                        command: {
-                          shell: 'bash',
-                          run: 'echo "MOCKED_OK"',
-                          cwd: '.',
-                          timeout_sec: 5,
-                        },
-                      }),
-                    },
-                  ],
-                },
-              ],
-            };
-            return payload;
-          },
-        },
-      };
-    };
+const thisFilePath = fileURLToPath(import.meta.url);
+const thisDir = path.dirname(thisFilePath);
+const originalUnstableMockModule = jest.unstable_mockModule.bind(jest);
+
+// Allow test files to continue using relative specifiers when mocking alongside this setup file.
+function resolveCallerPath() {
+  const error = new Error();
+  const stackLines = typeof error.stack === 'string' ? error.stack.split('\n').slice(2) : [];
+
+  for (const line of stackLines) {
+    const match =
+      line.match(/\((.*?):\d+:\d+\)/) ??
+      line.match(/at ([^\s]+:\d+:\d+)/) ??
+      line.match(/at ([^\s]+)/);
+
+    if (!match) continue;
+    let candidate = match[1];
+
+    if (candidate.startsWith('file://')) {
+      candidate = fileURLToPath(candidate);
+    }
+
+    if (candidate === thisFilePath) continue;
+    if (candidate.endsWith('tests/mockOpenAI.js')) continue;
+    if (candidate.includes('node_modules/jest')) continue;
+
+    return candidate;
   }
-  return originalLoad.apply(this, [request, parent, isMain]);
+
+  return null;
+}
+
+jest.unstable_mockModule = (specifier, factory, options) => {
+  if (typeof specifier === 'string' && specifier.startsWith('.')) {
+    const callerPath = resolveCallerPath();
+
+    if (callerPath) {
+      const targetPath = path.resolve(path.dirname(callerPath), specifier);
+      let rewrittenSpecifier = path.relative(thisDir, targetPath).replace(/\\/g, '/');
+
+      if (!rewrittenSpecifier.startsWith('.')) {
+        rewrittenSpecifier = `./${rewrittenSpecifier}`;
+      }
+
+      return originalUnstableMockModule(rewrittenSpecifier, factory, options);
+    }
+  }
+
+  return originalUnstableMockModule(specifier, factory, options);
 };
+
+function createMockResponse() {
+  return {
+    output: [
+      {
+        type: 'message',
+        content: [
+          {
+            type: 'output_text',
+            text: JSON.stringify({
+              message: 'Mocked response',
+              plan: [],
+              command: {
+                shell: 'bash',
+                run: 'echo "MOCKED_OK"',
+                cwd: '.',
+                timeout_sec: 5,
+              },
+            }),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function OpenAIMock() {
+  return {
+    responses: {
+      create: async () => createMockResponse(),
+    },
+  };
+}
+
+// Default stub used by suites that do not override the OpenAI client explicitly.
+const registerOpenAIMock = () => {
+  jest.unstable_mockModule('openai', () => ({
+    default: OpenAIMock,
+    OpenAI: OpenAIMock,
+  }));
+};
+
+const originalResetModules = typeof jest.resetModules === 'function' ? jest.resetModules.bind(jest) : null;
+
+if (originalResetModules) {
+  jest.resetModules = (...args) => {
+    const result = originalResetModules(...args);
+    registerOpenAIMock();
+    return result;
+  };
+}
+
+registerOpenAIMock();
+
+beforeEach(() => {
+  registerOpenAIMock();
+});


### PR DESCRIPTION
## Summary
- replace the legacy node module loader hack with an ESM Jest setup file that registers the default OpenAI mock via `jest.unstable_mockModule`
- ensure the helper keeps relative specifiers working for test-local mocks and re-applies the default client after `jest.resetModules`
- add an ESM Jest config that wires the setup file for all suites and document the change in the test context notes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2cefd708c83289b5592e1128fc0a4