### PR TITLE
docs: align guidance with pure ESM runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ STDOUT ______________
    * - Integration tests re-export the same function to run mocked scenarios.
    */
 
-  const chalk = require('chalk');
+  import chalk from 'chalk';
 
-  const { SYSTEM_PROMPT } = require('../config/systemPrompt');
-  const { getOpenAIClient, MODEL } = require('../openai/client');
+  import { SYSTEM_PROMPT } from '../config/systemPrompt.js';
+  import { getOpenAIClient, MODEL } from '../openai/client.js';
   …
 
 

--- a/context.md
+++ b/context.md
@@ -2,7 +2,7 @@
 
 ## Purpose & Scope
 - Node.js CLI agent that converses with an LLM using a strict JSON protocol, renders assistant plans/messages, and executes shell commands under human approval.
-- Current codebase lives under `src/` (ESM). `legacy/` retains the CommonJS mirror for backward compatibility.
+- Current codebase lives under `src/` (ESM). `legacy/` now serves as an archived snapshot of the pre-ESM tree rather than an actively supported CommonJS build.
 
 ## Quick Directory Map
 - Core runtime: [`src/context.md`](src/context.md)

--- a/legacy/context.md
+++ b/legacy/context.md
@@ -1,20 +1,20 @@
 # Directory Context: legacy
 
 ## Purpose
-- Preserves the pre-ESM CommonJS implementation of OpenAgent for reference or fallback usage.
-- Mirrors the modern `src/` tree with `.cjs` exports for environments that still rely on `require()`.
+- Archives the pre-ESM implementation of OpenAgent for historical reference only—this is no longer an actively supported CommonJS build.
+- Mirrors the modern `src/` tree to document how APIs evolved, even though the modules now live exclusively in ESM form.
 
 ## Key Files
-- `index.cjs`: CommonJS entry point matching `index.js` behaviour (auto-approve flags, template/shortcut dispatch).
-- `package.json`: minimal metadata for the legacy build.
-- `src/` (see child contexts) duplicates agent loop, CLI, commands, etc., in CommonJS form.
+- `index.js`: frozen entry point that captures the historical surface without promising ongoing compatibility.
+- `package.json`: minimal metadata so tests can still import the snapshot when auditing history.
+- `src/` (see child contexts) duplicates agent loop, CLI, commands, etc., in archival form.
 
 ## Positive Signals
-- Provides a stable rollback target during ongoing ESM migration work referenced in `docs/modernization-plan.md`.
+- Offers a reference when auditing older automation or documentation that still mentions the CommonJS build.
 
 ## Risks / Gaps
-- High maintenance cost: files can silently drift from the ESM equivalents without automated sync.
-- No dedicated tests ensure parity between `legacy/src` and `src` directories.
+- Without clear messaging contributors might assume CommonJS compatibility still exists; cross-link modern docs to avoid confusion.
+- The snapshot is not exercised by runtime tests, so it can drift—treat it as historical context only.
 
 ## Related Context
 - Modern ESM sources: [`../src/context.md`](../src/context.md)

--- a/legacy/src/agent/context.md
+++ b/legacy/src/agent/context.md
@@ -1,19 +1,19 @@
 # Directory Context: legacy/src/agent
 
 ## Purpose
-- CommonJS implementation of the agent loop for backward compatibility.
-- Exposes `createAgentLoop` and helper utilities via `module.exports` mirroring `src/agent/loop.js`.
+- Archived implementation of the agent loop retained for historical study now that the supported runtime is pure ESM.
+- Documents `createAgentLoop` and related helpers as they appeared before the CommonJS compatibility layer was removed.
 
 ## Key Concepts
 - `executeAgentPass` handles OpenAI call/observation cycle, approvals, and ESC cancellation.
 - `extractResponseText`, `parseReadSpecTokens`, `mergeReadSpecs`: parsing helpers shared with the ESM version.
 
 ## Positive Signals
-- Maintains identical behaviour to the ESM agent, including cancellation and command stats.
+- Shows how cancellation and command stats behaved prior to the ESM-only refactor, useful when auditing regressions.
 
 ## Risks / Gaps
-- Logic duplication means any bugfix in `src/agent/loop.js` must be manually ported.
-- CommonJS modules make tree-shaking or modern bundling harder.
+- Logic duplication means any bugfix in `src/agent/loop.js` would require manual backporting—avoid depending on this snapshot at runtime.
+- Historic CommonJS patterns linger in comments; clarify in docs that they're no longer representative of the supported build.
 
 ## Related Context
 - Modern agent loop: [`../../../src/agent/context.md`](../../../src/agent/context.md)

--- a/legacy/src/cli/context.md
+++ b/legacy/src/cli/context.md
@@ -1,7 +1,7 @@
 # Directory Context: legacy/src/cli
 
 ## Purpose
-- CommonJS versions of the CLI helpers (readline prompts, renderer, thinking animation).
+- Archived copies of the CLI helpers (readline prompts, renderer, thinking animation) from the pre-ESM build.
 
 ## Modules
 - `io.js`: readline wrapper with ESC support via event emitters.
@@ -9,10 +9,10 @@
 - `thinking.js`: spinner with elapsed time display.
 
 ## Positive Signals
-- Feature parity with ESM `src/cli` ensures UI behaviour is consistent across builds.
+- Useful when tracing UI changes back through time without touching the active ESM helpers.
 
 ## Risks / Gaps
-- Duplication: adjustments to the renderer/spinner must be copied manually from ESM sources.
+- Duplication invites drift; prefer editing the active ESM helpers and treat this directory as reference material only.
 
 ## Related Context
 - ESM CLI helpers: [`../../../src/cli/context.md`](../../../src/cli/context.md)

--- a/legacy/src/commands/context.md
+++ b/legacy/src/commands/context.md
@@ -1,17 +1,17 @@
 # Directory Context: legacy/src/commands
 
 ## Purpose
-- CommonJS counterparts to the command execution helpers in `src/commands`.
+- Archived counterparts to the command execution helpers in `src/commands`, kept for historical comparison now that the runtime is pure ESM.
 
 ## Modules
 - `run.js`, `read.js`, `edit.js`, `replace.js`, `browse.js`, `commandStats.js`, `preapproval.js`.
 
 ## Positive Signals
-- Provides compatibility for tooling still depending on `require()`.
+- Documents the previous command helper surface without promising ongoing compatibility.
 
 ## Risks / Gaps
-- Code mirrored from ESM without automated sync—bugfixes can diverge.
-- Lacks new utilities such as `escapeString` present in ESM (confirm before using legacy build).
+- Snapshot may lag behind active helpers; do not treat it as a supported build.
+- Newer utilities such as `escapeString` never landed here—call that out if referencing this directory.
 
 ## Related Context
 - ESM implementation: [`../../../src/commands/context.md`](../../../src/commands/context.md)

--- a/legacy/src/config/context.md
+++ b/legacy/src/config/context.md
@@ -1,16 +1,16 @@
 # Directory Context: legacy/src/config
 
 ## Purpose
-- Maintains CommonJS version of system prompt assembly utilities.
+- Archives the pre-ESM version of the system prompt assembly utilities for reference only.
 
 ## Key Module
 - `systemPrompt.js`: discovers `AGENTS.md`, concatenates developer/system prompts, mirrors logic from ESM `src/config/systemPrompt.js`.
 
 ## Positive Signals
-- Enables the legacy build to honour the same prompt composition rules as the modern entry point.
+- Records how prompt composition used to work, which helps when tracing historical behavioural changes.
 
 ## Risks / Gaps
-- Manual sync required with ESM prompt builder; divergences can change runtime behaviour unexpectedly.
+- Manual sync would be required to keep parity; prefer reading the active ESM module for real behaviour.
 
 ## Related Context
 - ESM configuration: [`../../../src/config/context.md`](../../../src/config/context.md)

--- a/legacy/src/context.md
+++ b/legacy/src/context.md
@@ -1,20 +1,20 @@
 # Directory Context: legacy/src
 
 ## Purpose
-- CommonJS mirror of the modern `src/` tree, keeping API-compatible modules for consumers still expecting `require()`.
+- Archival snapshot of the pre-ESM tree, preserved for historical comparison rather than active CommonJS distribution.
 
 ## Structure Overview
-- `agent/`: CJS agent loop identical in logic to `src/agent/loop.js`.
-- `cli/`: readline/render/thinking helpers with `module.exports`.
-- `commands/`: shell/browse/edit/etc. runners using CommonJS.
-- `config/`, `openai/`, `shortcuts/`, `templates/`, `utils/`: counterparts to the ESM directories.
+- `agent/`: Historical copy of the agent loop as it existed before the pure-ESM cutover.
+- `cli/`: Archived readline/render/thinking helpers that match the older layout.
+- `commands/`: Shell/browse/edit/etc. runners retained for comparison with the active ESM implementations.
+- `config/`, `openai/`, `shortcuts/`, `templates/`, `utils/`: counterparts kept solely to show past structure.
 
 ## Positive Signals
-- Direct copy of modern code ensures functionality parity when kept in sync.
+- Captures the previous module organisation for teams that need to audit historical behaviour.
 
 ## Risks / Gaps
-- No automation guarantees the mirror stays current after edits to the ESM sources.
-- Duplication inflates patch size for every change touching core modules.
+- Not exercised or synced with the active code; treat as read-only documentation.
+- Duplication can confuse newcomers—call out in documentation that CommonJS compatibility has been retired.
 
 ## Related Context
 - Parent legacy overview: [`../context.md`](../context.md)

--- a/legacy/src/openai/context.md
+++ b/legacy/src/openai/context.md
@@ -1,16 +1,16 @@
 # Directory Context: legacy/src/openai
 
 ## Purpose
-- CommonJS OpenAI client wrapper mirroring `src/openai/client.js`.
+- Archived OpenAI client wrapper mirroring `src/openai/client.js` prior to the pure-ESM transition.
 
 ## Key Module
 - `client.js`: memoizes the OpenAI SDK instance using environment variables; exports `MODEL`, `getOpenAIClient`, `resetOpenAIClient`.
 
 ## Positive Signals
-- Behaviour parity with ESM code keeps legacy entry point stable.
+- Captures how the client was previously instantiated, useful when tracing historical bugs.
 
 ## Risks / Gaps
-- Requires manual updates if environment handling changes in the ESM build.
+- Manual updates would be required to keep it aligned with the active ESM client; prefer the live code for authoritative behaviour.
 
 ## Related Context
 - ESM client: [`../../../src/openai/context.md`](../../../src/openai/context.md)

--- a/legacy/src/shortcuts/context.md
+++ b/legacy/src/shortcuts/context.md
@@ -1,16 +1,16 @@
 # Directory Context: legacy/src/shortcuts
 
 ## Purpose
-- CommonJS CLI helpers for managing `shortcuts/shortcuts.json`.
+- Archived CLI helpers for managing `shortcuts/shortcuts.json`, reflecting the pre-ESM build.
 
 ## Key Module
 - `cli.js`: loads shortcut definitions and handles `list/show/run` subcommands (invokes `process.exit` like ESM version).
 
 ## Positive Signals
-- Provides CLI parity for the legacy entry point.
+- Offers historical reference for how shortcut commands behaved prior to the ESM-only runtime.
 
 ## Risks / Gaps
-- Direct `process.exit` usage complicates testing; no abstraction between ESM and CJS variants.
+- Still relies on direct `process.exit` calls; treat it as documentation rather than executable code.
 
 ## Related Context
 - Modern shortcuts CLI: [`../../../src/shortcuts/context.md`](../../../src/shortcuts/context.md)

--- a/legacy/src/templates/context.md
+++ b/legacy/src/templates/context.md
@@ -1,16 +1,16 @@
 # Directory Context: legacy/src/templates
 
 ## Purpose
-- CommonJS helper for command templates, mirroring `src/templates/cli.js`.
+- Archived helper for command templates, mirroring `src/templates/cli.js` from before the pure-ESM transition.
 
 ## Key Module
 - `cli.js`: loads `templates/command-templates.json`, renders templates, and implements `list/show/render` subcommands.
 
 ## Positive Signals
-- Keeps legacy CLI consistent with ESM behaviour, including template variable interpolation.
+- Provides historical context for how template rendering evolved alongside the modern ESM helper.
 
 ## Risks / Gaps
-- Requires manual updates after template API changes in the ESM implementation.
+- Snapshot requires manual updates after template API changes; do not rely on it for runtime behaviour.
 
 ## Related Context
 - ESM counterpart: [`../../../src/templates/context.md`](../../../src/templates/context.md)

--- a/legacy/src/utils/context.md
+++ b/legacy/src/utils/context.md
@@ -1,16 +1,16 @@
 # Directory Context: legacy/src/utils
 
 ## Purpose
-- CommonJS versions of utility helpers (cancellation manager, text helpers, output combiner).
+- Archived copies of utility helpers (cancellation manager, text helpers, output combiner) preserved from the pre-ESM era.
 
 ## Modules
-- `cancellation.js`, `output.js`, `text.js`: match ESM logic but export via `module.exports`.
+- `cancellation.js`, `output.js`, `text.js`: mirror older logic for reference; the live implementations reside in `src/utils`.
 
 ## Positive Signals
-- Offers drop-in compatibility for legacy entry point without re-implementing logic.
+- Provides historical context when comparing new utility behaviour against earlier revisions.
 
 ## Risks / Gaps
-- Mirror can drift if new utilities (e.g., escape string helpers) are added only to ESM branch.
+- Snapshot can drift or omit newly added helpers (e.g., escape string utilities); do not rely on it for runtime usage.
 
 ## Related Context
 - Modern utilities: [`../../../src/utils/context.md`](../../../src/utils/context.md)

--- a/openagent-example.md
+++ b/openagent-example.md
@@ -294,7 +294,7 @@ STDOUT ______________
    * - `src/commands`, `src/cli`, and `src/config` supply focused utilities that the loop depends upon.
    */
 
-  require('dotenv').config();
+  import 'dotenv/config';
 
   const {
     getOpenAIClient,
@@ -343,11 +343,11 @@ STDOUT ______________
    * - Integration tests re-export the same function to run mocked scenarios.
    */
 
-  const chalk = require('chalk');
+  import chalk from 'chalk';
 
-  const { SYSTEM_PROMPT } = require('../config/systemPrompt');
-  const { getOpenAIClient, MODEL } = require('../openai/client');
-  const { startThinking, stopThinking } = require('../cli/thinking');
+  import { SYSTEM_PROMPT } from '../config/systemPrompt.js';
+  import { getOpenAIClient, MODEL } from '../openai/client.js';
+  import { startThinking, stopThinking } from '../cli/thinking.js';
   …
 
 
@@ -441,9 +441,8 @@ STDOUT ______________
    * - Tests mock these helpers through the root index re-exports.
    */
 
-  const readline = require('readline');
-  const { promisify } = require('util');
-  const chalk = require('chalk');
+  import * as readline from 'node:readline';
+  import chalk from 'chalk';
 
   function createInterface() {
     return readline.createInterface({
@@ -481,12 +480,14 @@ Runtime: 29ms
 Status: COMPLETED
 
 STDOUT ______________
-  src/agent/loop.js:const { createInterface, askHuman } = require('../cli/io');
-  src/agent/loop.js:  askHumanFn = askHuman,
-  src/agent/loop.js:        const userInput = await askHumanFn(rl, '\n ▷ ');
-  src/agent/loop.js:                const input = (await askHumanFn(rl, `
-  src/cli/io.js:async function askHuman(rl, prompt) {
+  src/cli/io.js:export async function askHuman(rl, prompt) {
   src/cli/io.js:  askHuman,
+  src/agent/loop.js:import { createInterface, askHuman, ESCAPE_EVENT } from '../cli/io.js';
+  src/agent/loop.js:  askHumanFn,
+  src/agent/loop.js:        await askHumanFn(
+  src/agent/loop.js:  askHumanFn = askHuman,
+  src/agent/loop.js:        const userInput = noHumanActive ? NO_HUMAN_AUTO_MESSAGE : await askHumanFn(rl, '\n ▷ ');
+  src/agent/loop.js:              askHumanFn,
 
 
 
@@ -965,7 +966,7 @@ STDOUT ______________
    * - Unit tests call `resetOpenAIClient()` via the root `index.js` re-export when they need a clean slate.
    */
 
-  const OpenAI = require('openai');
+  import OpenAI from 'openai';
 
   let memoizedClient = null;
 

--- a/src/context.md
+++ b/src/context.md
@@ -1,7 +1,7 @@
 # Directory Context: src
 
 ## Purpose
-- Primary ESM implementation of OpenAgent, replacing the legacy CommonJS tree.
+- Primary ESM implementation of OpenAgent; the former CommonJS tree now survives only in the archived `legacy/` snapshot.
 - Contains agent runtime, CLI presentation, command runners, configuration, and supporting utilities.
 
 ## Structure

--- a/tests/unit/context.md
+++ b/tests/unit/context.md
@@ -9,7 +9,7 @@
 - `cancellation.test.js`: exercises stack-based cancellation semantics.
 - `renderLanguage.test.js`, `renderPlan.test.js`: guard CLI rendering edge cases.
 - `replaceCommand.test.js`, `runCommand.test.js`: verify replacement logic and process management.
-- `index.test.js`, `legacyInterop.test.js`: confirm root exports and CommonJS interop remain intact.
+- `index.test.js`, `legacyInterop.test.js`: confirm root exports stay stable and that the archived `legacy/` bundle remains importable via ESM for historical audits.
 
 ## Positive Signals
 - Strong coverage of utility surfaces reduces risk of regressions during refactors.


### PR DESCRIPTION
## Summary
- replace remaining CommonJS snippets in README and openagent-example with import-based examples and updated command output
- rewrite the modernization plan to emphasize maintaining a pure ESM surface instead of a phased CommonJS migration
- refresh context files to describe the legacy tree as archival and remove promises of CommonJS compatibility

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e2cef959748328bd2f0bfb7fc0e9c6