### PR TITLE
docs: replace CommonJS snippets with ESM imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ STDOUT ______________
    * - Integration tests re-export the same function to run mocked scenarios.
    */
 
-  const chalk = require('chalk');
+  import chalk from 'chalk';
 
-  const { SYSTEM_PROMPT } = require('../config/systemPrompt');
-  const { getOpenAIClient, MODEL } = require('../openai/client');
+  import { SYSTEM_PROMPT } from '../config/systemPrompt.js';
+  import { getOpenAIClient, MODEL } from '../openai/client.js';
   …
 
 

--- a/context.md
+++ b/context.md
@@ -11,7 +11,7 @@
 - CLI assets: [`templates/context.md`](templates/context.md), [`shortcuts/context.md`](shortcuts/context.md)
 - Release notes: [`CHANGELOG.md`](CHANGELOG.md)
 - IDE settings: [`./.idea/context.md`](.idea/context.md)
-- Additional docs: [`docs/context.md`](docs/context.md)
+- Additional docs: [`docs/context.md`](docs/context.md); root-level `README.md` and `openagent-example.md` now highlight ESM `import` snippets so newcomers avoid legacy CommonJS patterns.
 
 ## Key Entry Points
 - `index.js`: bootstraps the agent loop, handles `templates`/`shortcuts` subcommands, exposes helpers for tests, honours startup flags (`--auto-approve`, `--nohuman`).

--- a/openagent-example.md
+++ b/openagent-example.md
@@ -294,10 +294,11 @@ STDOUT ______________
    * - `src/commands`, `src/cli`, and `src/config` supply focused utilities that the loop depends upon.
    */
 
-  require('dotenv').config();
+  import 'dotenv/config';
 
-  const {
-    getOpenAIClient,
+  import { getOpenAIClient, resetOpenAIClient, MODEL } from './src/openai/client.js';
+  import { startThinking, stopThinking, formatElapsedTime } from './src/cli/thinking.js';
+  import { createInterface, askHuman } from './src/cli/io.js';
   …
 
 
@@ -343,11 +344,11 @@ STDOUT ______________
    * - Integration tests re-export the same function to run mocked scenarios.
    */
 
-  const chalk = require('chalk');
+  import chalk from 'chalk';
 
-  const { SYSTEM_PROMPT } = require('../config/systemPrompt');
-  const { getOpenAIClient, MODEL } = require('../openai/client');
-  const { startThinking, stopThinking } = require('../cli/thinking');
+  import { SYSTEM_PROMPT } from '../config/systemPrompt.js';
+  import { getOpenAIClient, MODEL } from '../openai/client.js';
+  import { startThinking, stopThinking } from '../cli/thinking.js';
   …
 
 
@@ -441,9 +442,8 @@ STDOUT ______________
    * - Tests mock these helpers through the root index re-exports.
    */
 
-  const readline = require('readline');
-  const { promisify } = require('util');
-  const chalk = require('chalk');
+  import * as readline from 'node:readline';
+  import chalk from 'chalk';
 
   function createInterface() {
     return readline.createInterface({
@@ -481,7 +481,7 @@ Runtime: 29ms
 Status: COMPLETED
 
 STDOUT ______________
-  src/agent/loop.js:const { createInterface, askHuman } = require('../cli/io');
+  src/agent/loop.js:import { createInterface, askHuman } from '../cli/io.js';
   src/agent/loop.js:  askHumanFn = askHuman,
   src/agent/loop.js:        const userInput = await askHumanFn(rl, '\n ▷ ');
   src/agent/loop.js:                const input = (await askHumanFn(rl, `
@@ -965,7 +965,7 @@ STDOUT ______________
    * - Unit tests call `resetOpenAIClient()` via the root `index.js` re-export when they need a clean slate.
    */
 
-  const OpenAI = require('openai');
+  import OpenAI from 'openai';
 
   let memoizedClient = null;
 


### PR DESCRIPTION
## Summary
- update README transcript snippets to illustrate import-based usage of internal modules
- refresh openagent-example walkthrough excerpts to match the current ESM entry points
- note in the root context overview that top-level docs now highlight ESM imports

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68e313633edc8328b6dc227068093522