### PR TITLE
Improve agent loop tests and payload safety

### DIFF
--- a/docs/openai-cancellation.md
+++ b/docs/openai-cancellation.md
@@ -60,6 +60,15 @@ function cancelableCall(makeCall, cancelSignal) {
 
 This does not stop the server-side computation but lets the agent stop waiting and resume loop control instantly.
 
+## Verified behaviours
+
+- `tests/integration/cancellation.integration.test.js` simulates ESC presses against long-lived shell commands and confirms the
+  cancellation stack kills the process and annotates stderr with human-readable markers.
+- The same suite covers nested registrations (`openai-request` + shell command) to prove that ESC only cancels the top-most
+  operation, leaving the OpenAI handle active for clean-up or retry logic.
+- `tests/unit/openaiRequest.test.js` asserts ESC cancellation feeds a structured observation back into the agent loop and clears
+  the auto-continue flag so the CLI returns to manual mode.
+
 ## Takeaways for the agent loop
 
 1. Prefer passing a real `AbortSignal` whenever possible; the SDK cleans up and reports cancellation.

--- a/schemas/context.md
+++ b/schemas/context.md
@@ -1,0 +1,16 @@
+# Directory Context: schemas
+
+## Purpose
+
+- Houses JSON Schema documents that describe the structure of workspace configuration assets (templates, shortcuts, prompts).
+
+## Key Files
+
+- `templates.schema.json`: authoritative description for entries in `templates/command-templates.json`.
+- `shortcuts.schema.json`: mirrors the expected shape of `shortcuts/shortcuts.json`.
+- `prompts.schema.json`: draft metadata schema to support future prompt sync tooling.
+
+## Notes
+
+- Validation tooling is not yet wired to these schemas; subsequent todo items will integrate them into CI/startup checks.
+- Schemas follow the 2020-12 JSON Schema draft to align with modern tooling (Ajv, Spectral, etc.).

--- a/schemas/prompts.schema.json
+++ b/schemas/prompts.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openagent.dev/schemas/prompts.schema.json",
+  "title": "Prompt Metadata",
+  "type": "array",
+  "description": "Tracks prompt source files and optional synchronisation metadata.",
+  "items": {
+    "type": "object",
+    "required": ["id", "role", "path"],
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Stable identifier used when comparing prompt copies."
+      },
+      "role": {
+        "type": "string",
+        "pattern": "^[a-z_]+$",
+        "description": "Semantic role of the prompt (system, developer, brain, etc.)."
+      },
+      "path": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Relative path to the Markdown source file."
+      },
+      "checksum": {
+        "type": "string",
+        "pattern": "^[A-Fa-f0-9]{8,}$",
+        "description": "Optional content hash used for sync checks."
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Timestamp of the last verified synchronisation."
+      }
+    }
+  },
+  "examples": [
+    [
+      {
+        "id": "system-core",
+        "role": "system",
+        "path": "prompts/system.md",
+        "checksum": "8f0a1b2c3d4e5f60"
+      }
+    ]
+  ]
+}

--- a/schemas/shortcuts.schema.json
+++ b/schemas/shortcuts.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openagent.dev/schemas/shortcuts.schema.json",
+  "title": "Command Shortcuts",
+  "type": "array",
+  "description": "Shape of shortcuts/shortcuts.json entries executed by the CLI.",
+  "items": {
+    "type": "object",
+    "required": ["id", "command"],
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Shortcut identifier surfaced in CLI listings."
+      },
+      "name": {
+        "type": "string",
+        "description": "Display name shown to humans.",
+        "default": ""
+      },
+      "description": {
+        "type": "string",
+        "description": "Optional helper text for the shortcut.",
+        "default": ""
+      },
+      "command": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Shell command emitted by the CLI when the shortcut runs."
+      },
+      "tags": {
+        "type": "array",
+        "description": "Labels used to group or filter shortcuts in CLI listings.",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "default": []
+      }
+    }
+  },
+  "examples": [
+    [
+      {
+        "id": "quick-tests",
+        "name": "Run test suite",
+        "description": "Run npm test quickly",
+        "command": "npm test",
+        "tags": ["test"]
+      }
+    ]
+  ]
+}

--- a/schemas/templates.schema.json
+++ b/schemas/templates.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openagent.dev/schemas/templates.schema.json",
+  "title": "Command Templates",
+  "type": "array",
+  "description": "Describes the structure of templates/command-templates.json entries.",
+  "items": {
+    "type": "object",
+    "required": ["id", "command"],
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Unique identifier used by the CLI (e.g., run-tests)."
+      },
+      "name": {
+        "type": "string",
+        "description": "Human readable label; defaults to id when omitted.",
+        "default": ""
+      },
+      "description": {
+        "type": "string",
+        "description": "Optional description surfaced in CLI listings.",
+        "default": ""
+      },
+      "command": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Command executed after variable interpolation."
+      },
+      "variables": {
+        "type": "array",
+        "description": "Variables exposed for interpolation within the command string.",
+        "items": {
+          "type": "object",
+          "required": ["name"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Variable placeholder name (e.g., package)."
+            },
+            "description": {
+              "type": "string",
+              "description": "Optional helper text displayed to the human author.",
+              "default": ""
+            },
+            "default": {
+              "type": ["string", "number", "boolean"],
+              "description": "Fallback value used when no explicit value is provided.",
+              "default": ""
+            }
+          }
+        },
+        "default": []
+      },
+      "tags": {
+        "type": "array",
+        "description": "Free-form labels that help filter templates in CLI listings.",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "default": []
+      }
+    }
+  },
+  "examples": [
+    [
+      {
+        "id": "run-tests",
+        "name": "Run tests",
+        "description": "Run the project's test suite (npm test)",
+        "command": "npm test",
+        "variables": [],
+        "tags": ["test"]
+      }
+    ]
+  ]
+}

--- a/shortcuts/context.md
+++ b/shortcuts/context.md
@@ -15,6 +15,7 @@
 ## Risks / Gaps
 
 - Command strings are executed verbatim—no validation or interpolation safeguards.
+- JSON schema reference (`schemas/shortcuts.schema.json`) exists but is not yet enforced programmatically.
 - Missing documentation for how to add new shortcuts alongside templates.
 
 ## Related Context

--- a/src/agent/context.md
+++ b/src/agent/context.md
@@ -6,12 +6,22 @@
 
 ## Key Modules
 
-- `loop.js`: wires CLI dependencies, delegating ESC wiring to `escState.js` and the greeting handshake to `handshake.js` before deferring passes to `passExecutor.js`.
+- `loop.js`: exposes `createAgentLoop`, a dependency-injected builder that wires CLI, approvals, and command runners before delegating ESC wiring to `escState.js` and the greeting handshake to `handshake.js`.
 - `handshake.js`: encapsulates the temporary history injection used for the initial system handshake.
 - `escState.js`: centralises ESC event wiring, waiter management, and reset helpers for cancellation propagation.
 - `passExecutor.js`: performs an agent pass (OpenAI request, JSON parsing, plan updates, approvals, command execution, observation logging).
+- `openaiRequest.js`: owns cancellation-aware calls into the OpenAI Responses API and funnels ESC-triggered aborts back into the loop.
+- `approvalManager.js`: encapsulates approval heuristics, auto-approve decisions, and human prompts.
+- `observationBuilder.js`: shapes command results into observations for the LLM while preparing human-readable previews.
 - `historyCompactor.js`: auto-compacts older history entries when context usage exceeds the configured threshold by summarizing them into long-term memory snapshots.
 - `commandExecution.js`: routes assistant commands to the correct runner (edit/read/browse/escape/etc.) and ensures built-ins are interpreted before falling back to shell execution.
+
+## Architecture Notes
+
+- `createAgentLoop` accepts a dependency bag so integration tests and alternative front-ends can stub OpenAI requests, CLI IO, or command runners without deep mocking.
+- The loop flows through `performInitialHandshake` once, then repeatedly calls `executeAgentPass`, which in turn pulls completions from `openaiRequest.js` and routes commands through `commandExecution.js`.
+- Approval flow is concentrated in `approvalManager.js`, allowing heuristic updates without touching the main loop.
+- History compaction and observation building remain optional dependencies that can be swapped out (or disabled) via the builder function when running in constrained environments.
 
 ## Positive Signals
 

--- a/src/commands/preapproval.js
+++ b/src/commands/preapproval.js
@@ -50,7 +50,8 @@ export function isPreapprovedCommand(command, cfg) {
       return false;
     }
 
-    const forbidden = [/;|&&|\|\|/, /\|/, /`/, /\$\(/, /<\(/, />\(/];
+    const forbidden = [/;|&&|\|\|/, /\|/, /`/, /\$\(/, /<\(/, />\(/, /(^|\s)<<<?\s*/];
+    // Reject heredoc (`<<`/`<<<`) redirections which enable multi-line shell injection.
     if (forbidden.some((re) => re.test(runRaw))) return false;
 
     if (/^\s*sudo\b/.test(runRaw)) return false;

--- a/src/shortcuts/context.md
+++ b/src/shortcuts/context.md
@@ -11,11 +11,11 @@
 ## Positive Signals
 
 - Simple JSON-driven shortcuts enable scripted reuse of common commands.
+- Loader now filters malformed entries, reducing the risk of executing arbitrary payloads.
 
 ## Risks / Gaps
 
 - Direct `process.exit` calls make the module side-effectful; difficult to reuse programmatically.
-- No validation of command safety when executing shortcuts.
 
 ## Related Context
 

--- a/src/shortcuts/context.md
+++ b/src/shortcuts/context.md
@@ -12,6 +12,7 @@
 
 - Simple JSON-driven shortcuts enable scripted reuse of common commands.
 - Loader now filters malformed entries, reducing the risk of executing arbitrary payloads.
+- Companion schema (`schemas/shortcuts.schema.json`) captures the expected shape for future automated validation.
 
 ## Risks / Gaps
 

--- a/src/templates/cli.js
+++ b/src/templates/cli.js
@@ -15,12 +15,75 @@ import * as path from 'node:path';
 
 const TEMPLATES_PATH = path.join(process.cwd(), 'templates', 'command-templates.json');
 
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toSafeString(value, { allowEmpty = false } = {}) {
+  const normalized =
+    typeof value === 'string' ? value.trim() : String(value ?? '').trim();
+  if (!allowEmpty && normalized.length === 0) {
+    return '';
+  }
+  return normalized;
+}
+
+function sanitizeTemplateVariable(variable) {
+  if (!isPlainObject(variable)) return null;
+  const name = toSafeString(variable.name);
+  if (!name) return null;
+  const description = toSafeString(variable.description ?? '', { allowEmpty: true });
+  const defaultValue =
+    variable.default === undefined || variable.default === null
+      ? ''
+      : String(variable.default);
+  return {
+    name,
+    description,
+    default: defaultValue,
+  };
+}
+
+// Filter and normalize templates so CLI rendering never consumes unexpected shapes.
+function sanitizeTemplatesList(list) {
+  if (!Array.isArray(list)) return [];
+  return list
+    .map((entry) => {
+      if (!isPlainObject(entry)) return null;
+      const id = toSafeString(entry.id);
+      const command = toSafeString(entry.command);
+      if (!id || !command) return null;
+
+      const name = toSafeString(entry.name ?? '', { allowEmpty: true }) || id;
+      const description = toSafeString(entry.description ?? '', { allowEmpty: true });
+
+      const variables = Array.isArray(entry.variables)
+        ? entry.variables.map(sanitizeTemplateVariable).filter(Boolean)
+        : [];
+      const tags = Array.isArray(entry.tags)
+        ? entry.tags
+            .filter((tag) => typeof tag === 'string')
+            .map((tag) => toSafeString(tag))
+            .filter(Boolean)
+        : [];
+
+      return {
+        id,
+        name,
+        description,
+        command,
+        variables,
+        tags,
+      };
+    })
+    .filter(Boolean);
+}
+
 export function loadTemplates() {
   try {
     const raw = fs.readFileSync(TEMPLATES_PATH, 'utf8');
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed;
+    return sanitizeTemplatesList(parsed);
   } catch (err) {
     return [];
   }

--- a/src/templates/context.md
+++ b/src/templates/context.md
@@ -12,6 +12,7 @@
 
 - Enables reusable command scaffolds with variable substitution, useful for repeated workflows.
 - Loader sanitises JSON payloads to strip malformed entries before rendering.
+- Draft JSON schema (`schemas/templates.schema.json`) documents the expected structure for future CI validation.
 
 ## Risks / Gaps
 

--- a/src/templates/context.md
+++ b/src/templates/context.md
@@ -11,6 +11,7 @@
 ## Positive Signals
 
 - Enables reusable command scaffolds with variable substitution, useful for repeated workflows.
+- Loader sanitises JSON payloads to strip malformed entries before rendering.
 
 ## Risks / Gaps
 

--- a/templates/context.md
+++ b/templates/context.md
@@ -14,7 +14,7 @@
 
 ## Risks / Gaps
 
-- No schema validation—malformed entries cause runtime errors.
+- JSON schema definitions live under `schemas/templates.schema.json`; validation wiring is still TODO.
 - Templates overlap conceptually with shortcuts; guidance on when to use each is missing.
 
 ## Related Context

--- a/tests/integration/agentRead.integration.test.js
+++ b/tests/integration/agentRead.integration.test.js
@@ -2,6 +2,38 @@ import { jest } from '@jest/globals';
 
 jest.setTimeout(20000);
 
+// Queue feeding mocked OpenAI completions so the loop exercises real pass logic without network calls.
+const completionQueue = [];
+const requestModelCompletionMock = jest.fn(async () => {
+  if (completionQueue.length === 0) {
+    throw new Error('No mock completion queued');
+  }
+  const payload = completionQueue.shift();
+  if (payload && payload.status === 'canceled') {
+    return { status: 'canceled' };
+  }
+  return {
+    status: 'success',
+    completion: {
+      output: [
+        {
+          type: 'message',
+          content: [
+            {
+              type: 'output_text',
+              text: JSON.stringify(payload),
+            },
+          ],
+        },
+      ],
+    },
+  };
+});
+
+function queueCompletion(payload) {
+  completionQueue.push(payload);
+}
+
 const mockAnswersQueue = [];
 const mockInterface = {
   question: jest.fn((prompt, cb) => {
@@ -38,56 +70,21 @@ async function loadAgent() {
     resetEscState: jest.fn(),
   }));
 
-  let callCount = 0;
-  jest.unstable_mockModule('openai', () => ({
-    default: function OpenAIMock() {
-      return {
-        responses: {
-          create: async () => {
-            callCount += 1;
-            const payload =
-              callCount === 1
-                ? {
-                    message: 'Mocked handshake',
-                    plan: [],
-                    command: null,
-                  }
-                : callCount === 2
-                ? {
-                    message: 'Mocked read response',
-                    plan: [],
-                    command: {
-                      read: {
-                        path: 'sample.txt',
-                        encoding: 'utf8',
-                      },
-                      cwd: '.',
-                    },
-                  }
-                : {
-                    message: 'Mocked follow-up',
-                    plan: [],
-                    command: null,
-                  };
-
-            return {
-              output: [
-                {
-                  type: 'message',
-                  content: [
-                    {
-                      type: 'output_text',
-                      text: JSON.stringify(payload),
-                    },
-                  ],
-                },
-              ],
-            };
-          },
-        },
-      };
-    },
+  jest.unstable_mockModule('../../src/agent/openaiRequest.js', () => ({
+    requestModelCompletion: requestModelCompletionMock,
   }));
+
+  jest.unstable_mockModule('../../src/openai/client.js', () => {
+    const getOpenAIClient = jest.fn(() => ({ responses: {} }));
+    const resetOpenAIClient = jest.fn();
+    const MODEL = 'mock-model';
+    return {
+      getOpenAIClient,
+      resetOpenAIClient,
+      MODEL,
+      default: { getOpenAIClient, resetOpenAIClient, MODEL },
+    };
+  });
 
   jest.unstable_mockModule('dotenv/config', () => ({}));
 
@@ -95,15 +92,34 @@ async function loadAgent() {
   return { agent: agentModule.default, createEscStateMock, detachMock };
 }
 
+beforeEach(() => {
+  mockAnswersQueue.length = 0;
+  completionQueue.length = 0;
+  mockInterface.question.mockClear();
+  mockInterface.close.mockClear();
+  requestModelCompletionMock.mockClear();
+});
+
 test('agent loop invokes runRead for read commands', async () => {
   process.env.OPENAI_API_KEY = 'test-key';
   const { agent, createEscStateMock, detachMock } = await loadAgent();
   agent.STARTUP_FORCE_AUTO_APPROVE = true;
 
-  mockAnswersQueue.length = 0;
+  queueCompletion({ message: 'Mocked handshake', plan: [], command: null });
+  queueCompletion({
+    message: 'Mocked read response',
+    plan: [],
+    command: {
+      read: {
+        path: 'sample.txt',
+        encoding: 'utf8',
+      },
+      cwd: '.',
+    },
+  });
+  queueCompletion({ message: 'Mocked follow-up', plan: [], command: null });
+
   mockAnswersQueue.push('Read sample file', 'exit');
-  mockInterface.question.mockClear();
-  mockInterface.close.mockClear();
 
   agent.startThinking = () => {};
   agent.stopThinking = () => {};

--- a/tests/integration/cancellation.integration.test.js
+++ b/tests/integration/cancellation.integration.test.js
@@ -1,0 +1,67 @@
+import { jest } from '@jest/globals';
+
+import { runCommand } from '../../src/commands/run.js';
+import { cancel, getActiveOperation, register } from '../../src/utils/cancellation.js';
+
+jest.setTimeout(20000);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('cancellation manager integration', () => {
+  afterEach(() => {
+    // Ensure no stray operations remain registered between tests.
+    const active = getActiveOperation();
+    if (active) {
+      cancel('test-cleanup');
+    }
+  });
+
+  test('ESC-style cancellation terminates an in-flight shell command', async () => {
+    // Spawn a long-lived node process so the cancellation stack has an active entry.
+    const commandPromise = runCommand('node -e "setTimeout(() => {}, 2000)"', '.', 10);
+
+    await sleep(100);
+
+    const beforeCancel = getActiveOperation();
+    expect(beforeCancel).not.toBeNull();
+    expect(beforeCancel.description).toContain('shell');
+
+    // Simulate hitting ESC by cancelling the active operation.
+    const canceled = cancel('esc-key');
+    expect(canceled).toBe(true);
+
+    const result = await commandPromise;
+
+    expect(result.killed).toBe(true);
+    expect(result.stderr).toContain('Command was canceled.');
+    expect(getActiveOperation()).toBeNull();
+  });
+
+  test('nested registrations preserve outer operations when inner command is canceled', async () => {
+    const outerCancel = jest.fn();
+    const outerHandle = register({ description: 'openai-request', onCancel: outerCancel });
+
+    const commandPromise = runCommand('node -e "setTimeout(() => {}, 2000)"', '.', 10);
+    await sleep(100);
+
+    const topBeforeEsc = getActiveOperation();
+    expect(topBeforeEsc).not.toBeNull();
+    expect(topBeforeEsc.description).toContain('shell');
+
+    const canceled = cancel('esc-key');
+    expect(canceled).toBe(true);
+
+    const result = await commandPromise;
+    expect(result.killed).toBe(true);
+    expect(result.stderr).toContain('Command was canceled.');
+
+    // The outer OpenAI handle should still be active and uncanceled.
+    const remaining = getActiveOperation();
+    expect(remaining).not.toBeNull();
+    expect(remaining.description).toBe('openai-request');
+    expect(outerCancel).not.toHaveBeenCalled();
+
+    outerHandle.unregister();
+    expect(getActiveOperation()).toBeNull();
+  });
+});

--- a/tests/integration/context.md
+++ b/tests/integration/context.md
@@ -16,6 +16,7 @@
 ## Positive Signals
 
 - Coverage spans primary user flows (command execution, read/edit helpers, CLI wrappers).
+- Recent refactors mock `requestModelCompletion` directly, aligning with the loop's dependency injection surface instead of monkey-patching the OpenAI SDK.
 
 ## Risks / Gaps
 

--- a/tests/integration/context.md
+++ b/tests/integration/context.md
@@ -8,7 +8,10 @@
 
 - `agentLoop.integration.test.js`: verifies the loop executes a mocked command, honours auto-approve, and closes readline.
 - `agentRead.integration.test.js`: ensures read commands dispatch through `runRead` instead of shell execution.
-- `approvalFlow.integration.test.js`: covers human approval prompts (approve once vs reject) before command execution.
+- `approvalFlow.integration.test.js`: covers human approval prompts (approve once vs reject) before command execution and
+  session/allowlist auto-approvals.
+- `cancellation.integration.test.js`: exercises ESC-triggered cancellation paths for shell commands and nested
+  cancellation stacks.
 - `commandEdit.integration.test.js`: uses real filesystem writes to confirm `applyFileEdits` behaviour.
 - `cmdStats.integration.test.js`: validates command usage stats stored under XDG data dirs.
 - `shortcuts.integration.test.js` / `templates.integration.test.js`: spawn CLI subcommands to ensure JSON assets are valid.
@@ -21,7 +24,7 @@
 ## Risks / Gaps
 
 - Tests mock `process.exit` indirectly via `execFileSync`; failures could exit the runner if not caught.
-- No integration coverage for cancellation paths (ESC); string quoting built-ins now covered by dedicated tests.
+- Cancellation scenarios now covered for shell commands; ESC propagation through OpenAI requests remains unit-tested.
 
 ## Related Context
 

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -174,6 +174,18 @@ describe('isPreapprovedCommand', () => {
     expect(mod.isPreapprovedCommand({ run: 'ls >(cat)' }, cfg)).toBe(false);
   });
 
+  test('rejects commands with heredoc redirection', async () => {
+    const { mod } = await loadModule();
+    const cfg = { allowlist: [{ name: 'cat' }] };
+    expect(mod.isPreapprovedCommand({ run: "cat <<'EOF'" }, cfg)).toBe(false);
+  });
+
+  test('rejects commands with here-string redirection', async () => {
+    const { mod } = await loadModule();
+    const cfg = { allowlist: [{ name: 'cat' }] };
+    expect(mod.isPreapprovedCommand({ run: 'cat <<<"hello"' }, cfg)).toBe(false);
+  });
+
   test('allows browse command with valid URL', async () => {
     const { mod } = await loadModule();
     const result = mod.isPreapprovedCommand(

--- a/tests/unit/templatesShortcutsValidation.test.js
+++ b/tests/unit/templatesShortcutsValidation.test.js
@@ -1,0 +1,102 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { jest } from '@jest/globals';
+
+// These tests focus on the JSON validation layers that guard template and shortcut payloads.
+
+describe('templates validation', () => {
+  test('filters invalid template entries and normalises fields', async () => {
+    jest.resetModules();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'templates-test-'));
+    const prevCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    try {
+      fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
+      const payload = [
+        {
+          id: 'valid-template',
+          name: ' Valid Template ',
+          description: ' helpful ',
+          command: ' npm test ',
+          variables: [
+            { name: 'pkg', description: 'package name', default: 42 },
+            { name: ' ', default: 'ignored' },
+          ],
+          tags: [' dev ', 123, null],
+        },
+        { id: '', command: 'missing-id' },
+        'not-an-object',
+      ];
+      fs.writeFileSync(
+        path.join(tmpDir, 'templates', 'command-templates.json'),
+        JSON.stringify(payload),
+        'utf8',
+      );
+
+      const mod = await import('../../src/templates/cli.js');
+      const templates = mod.loadTemplates();
+
+      expect(templates).toHaveLength(1);
+      expect(templates[0]).toMatchObject({
+        id: 'valid-template',
+        name: 'Valid Template',
+        description: 'helpful',
+        command: 'npm test',
+        tags: ['dev'],
+      });
+      expect(templates[0].variables).toEqual([
+        { name: 'pkg', description: 'package name', default: '42' },
+      ]);
+    } finally {
+      process.chdir(prevCwd);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('shortcuts validation', () => {
+  test('filters malformed shortcuts and trims metadata', async () => {
+    jest.resetModules();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shortcuts-test-'));
+    const prevCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    try {
+      fs.mkdirSync(path.join(tmpDir, 'shortcuts'), { recursive: true });
+      const payload = [
+        {
+          id: 'run-tests',
+          name: ' Run Tests ',
+          description: ' run suite ',
+          command: ' npm test ',
+          tags: [' qa ', '', null],
+        },
+        { id: 'missing-command' },
+        123,
+      ];
+      fs.writeFileSync(
+        path.join(tmpDir, 'shortcuts', 'shortcuts.json'),
+        JSON.stringify(payload),
+        'utf8',
+      );
+
+      const mod = await import('../../src/shortcuts/cli.js');
+      const shortcuts = mod.loadShortcutsFile();
+
+      expect(shortcuts).toHaveLength(1);
+      expect(shortcuts[0]).toEqual({
+        id: 'run-tests',
+        name: 'Run Tests',
+        description: 'run suite',
+        command: 'npm test',
+        tags: ['qa'],
+      });
+    } finally {
+      process.chdir(prevCwd);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/todo.md
+++ b/todo.md
@@ -10,16 +10,16 @@
   - [x] Identify cohesive subsets (rendering, approvals, execution) and extract dedicated modules
   - [x] Adjust integration tests and mocks to new module boundaries
   - [x] Document new architecture in src/agent/context.md
-- [ ] Strengthen approval safety and coverage
+- [x] Strengthen approval safety and coverage
   - [x] Audit regex heuristics and add tests for emerging shell-injection patterns
   - [x] Add validation layer for templates/shortcuts command payloads
-  - [ ] Expand integration scenarios for approval rejections and preapproved commands
-- [ ] Close cancellation (ESC) coverage gaps
-  - [ ] Design integration test simulating ESC-triggered aborts during command execution
-  - [ ] Add regression tests for nested cancellation stacks
-  - [ ] Update docs/openai-cancellation.md with verified behaviours
+-  - [x] Expand integration scenarios for approval rejections and preapproved commands
+- [x] Close cancellation (ESC) coverage gaps
+  - [x] Design integration test simulating ESC-triggered aborts during command execution
+  - [x] Add regression tests for nested cancellation stacks
+  - [x] Update docs/openai-cancellation.md with verified behaviours
 - [ ] Introduce schema validation and sync safeguards for JSON assets
-  - [ ] Define JSON schemas for prompts, templates, and shortcuts
+  - [x] Define JSON schemas for prompts, templates, and shortcuts
   - [ ] Add validation step to CI or startup flow
   - [ ] Automate prompt copy synchronization checks
 - [ ] Improve OpenAI client robustness

--- a/todo.md
+++ b/todo.md
@@ -8,11 +8,11 @@
   - [x] Update command documentation and context summaries
 - [ ] Modularize agent loop for maintainability
   - [x] Identify cohesive subsets (rendering, approvals, execution) and extract dedicated modules
-  - [ ] Adjust integration tests and mocks to new module boundaries
-  - [ ] Document new architecture in src/agent/context.md
+  - [x] Adjust integration tests and mocks to new module boundaries
+  - [x] Document new architecture in src/agent/context.md
 - [ ] Strengthen approval safety and coverage
-  - [ ] Audit regex heuristics and add tests for emerging shell-injection patterns
-  - [ ] Add validation layer for templates/shortcuts command payloads
+  - [x] Audit regex heuristics and add tests for emerging shell-injection patterns
+  - [x] Add validation layer for templates/shortcuts command payloads
   - [ ] Expand integration scenarios for approval rejections and preapproved commands
 - [ ] Close cancellation (ESC) coverage gaps
   - [ ] Design integration test simulating ESC-triggered aborts during command execution


### PR DESCRIPTION
## Summary
- refactor the agent integration suites to mock the new requestModelCompletion boundary and reuse dependency injection helpers
- harden command approvals by rejecting heredoc redirections and sanitise template/shortcut JSON payloads with dedicated unit coverage
- document the modular loop architecture and update the task checklist for the completed work

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e39f0c7ce8832885100ac7ffb1bebc