### PR TITLE
Refactor agent loop to event-driven runtime

### DIFF
--- a/src/agent/approvalManager.js
+++ b/src/agent/approvalManager.js
@@ -18,7 +18,7 @@ export class ApprovalManager {
    * @param {(command: Object) => boolean} options.isSessionApproved
    * @param {(command: Object) => void} options.approveForSession
    * @param {() => boolean} options.getAutoApproveFlag
-   * @param {(rl: Object, prompt: string) => Promise<string>} options.askHuman
+   * @param {(prompt: string) => Promise<string>} options.askHuman
    * @param {Object} options.preapprovedCfg
    * @param {(message: string) => void} [options.logInfo]
    * @param {(message: string) => void} [options.logWarn]
@@ -74,11 +74,10 @@ export class ApprovalManager {
   /**
    * Prompt the human for approval when auto-approval fails.
    * @param {Object} params
-   * @param {Object} params.rl
    * @param {Object} params.command
    * @returns {Promise<ApprovalOutcome>}
    */
-  async requestHumanDecision({ rl, command }) {
+  async requestHumanDecision({ command }) {
     const prompt = [
       'Approve running this command?',
       '  1) Yes (run once)',
@@ -88,7 +87,7 @@ export class ApprovalManager {
     ].join('\n');
 
     while (true) {
-      const raw = this.askHuman ? await this.askHuman(rl, prompt) : '';
+      const raw = this.askHuman ? await this.askHuman(prompt) : '';
       const input = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
 
       if (input === '1' || input === 'y' || input === 'yes') {

--- a/src/agent/context.md
+++ b/src/agent/context.md
@@ -6,9 +6,9 @@
 
 ## Key Modules
 
-- `loop.js`: wires CLI dependencies, delegating ESC wiring to `escState.js` and the greeting handshake to `handshake.js` before deferring passes to `passExecutor.js`.
+- `loop.js`: exposes the event-driven runtime (`createAgentRuntime`) that emits structured JSON events and wraps it with the legacy `createAgentLoop` helper for compatibility.
 - `handshake.js`: encapsulates the temporary history injection used for the initial system handshake.
-- `escState.js`: centralises ESC event wiring, waiter management, and reset helpers for cancellation propagation.
+- `escState.js`: centralises cancellation state, allowing UI-triggered events to notify in-flight operations.
 - `passExecutor.js`: performs an agent pass (OpenAI request, JSON parsing, plan updates, approvals, command execution, observation logging).
 - `historyCompactor.js`: auto-compacts older history entries when context usage exceeds the configured threshold by summarizing them into long-term memory snapshots.
 - `commandExecution.js`: routes assistant commands to the correct runner (edit/read/browse/escape/etc.) and ensures built-ins are interpreted before falling back to shell execution.

--- a/src/agent/handshake.js
+++ b/src/agent/handshake.js
@@ -1,5 +1,3 @@
-import chalk from 'chalk';
-
 /**
  * Performs the initial system handshake by temporarily inserting a prompt
  * into the conversation history and executing a single agent pass.
@@ -10,10 +8,7 @@ export async function performInitialHandshake({
   executePass,
   openai,
   model,
-  renderPlanFn,
-  renderMessageFn,
-  renderCommandFn,
-  renderContextUsageFn,
+  emitEvent,
   runCommandFn,
   runBrowseFn,
   runEditFn,
@@ -26,13 +21,12 @@ export async function performInitialHandshake({
   getNoHumanFlag,
   setNoHumanFlag,
   planReminderMessage,
-  rl,
   startThinkingFn,
   stopThinkingFn,
   escState,
   approvalManager,
   historyCompactor,
-  logger = console,
+  logger = { error: () => {} },
 }) {
   if (!Array.isArray(history)) {
     throw new Error('Handshake requires a mutable history array');
@@ -51,10 +45,7 @@ export async function performInitialHandshake({
       openai,
       model,
       history,
-      renderPlanFn,
-      renderMessageFn,
-      renderCommandFn,
-      renderContextUsageFn,
+      emitEvent,
       runCommandFn,
       runBrowseFn,
       runEditFn,
@@ -67,7 +58,6 @@ export async function performInitialHandshake({
       getNoHumanFlag,
       setNoHumanFlag,
       planReminderMessage,
-      rl,
       startThinkingFn,
       stopThinkingFn,
       escState,
@@ -76,8 +66,8 @@ export async function performInitialHandshake({
     });
   } catch (error) {
     stopThinkingFn?.();
-    logger.error(chalk.yellow('[handshake] Failed to complete initial handshake.'));
-    logger.error(error);
+    logger.error?.('[handshake] Failed to complete initial handshake.');
+    logger.error?.(error);
   } finally {
     const index = history.findIndex(
       (entry, idx) =>

--- a/src/utils/asyncQueue.js
+++ b/src/utils/asyncQueue.js
@@ -1,0 +1,75 @@
+/**
+ * Lightweight async queue used to model agent event streams.
+ *
+ * Implements a push-based buffer with backpressure via awaiting `next()`.
+ */
+
+const DONE = Symbol('async-queue-done');
+
+export function createAsyncQueue() {
+  const values = [];
+  const waiters = [];
+  let closed = false;
+
+  function flushWaiters(value) {
+    while (waiters.length > 0) {
+      const resolve = waiters.shift();
+      try {
+        resolve(value);
+      } catch {
+        // Ignore waiter resolution failures; downstream consumers decide.
+      }
+    }
+  }
+
+  function push(value) {
+    if (closed) {
+      return false;
+    }
+    if (waiters.length > 0) {
+      flushWaiters(value);
+    } else {
+      values.push(value);
+    }
+    return true;
+  }
+
+  function close() {
+    if (closed) return;
+    closed = true;
+    flushWaiters(DONE);
+  }
+
+  async function next() {
+    if (values.length > 0) {
+      return values.shift();
+    }
+    if (closed) {
+      return DONE;
+    }
+    return new Promise((resolve) => {
+      waiters.push(resolve);
+    });
+  }
+
+  async function *iterate() {
+    while (true) {
+      const value = await next();
+      if (value === DONE) {
+        return;
+      }
+      yield value;
+    }
+  }
+
+  return {
+    push,
+    close,
+    next,
+    [Symbol.asyncIterator]: iterate,
+  };
+}
+
+export const QUEUE_DONE = DONE;
+
+export default { createAsyncQueue, QUEUE_DONE };

--- a/tests/unit/approvalManager.test.js
+++ b/tests/unit/approvalManager.test.js
@@ -49,8 +49,6 @@ describe('ApprovalManager.shouldAutoApprove', () => {
 });
 
 describe('ApprovalManager.requestHumanDecision', () => {
-  const rl = {};
-
   const makeManager = ({ responses }) => {
     const logs = { info: [], warn: [], success: [] };
     let approvedCommand = null;
@@ -76,7 +74,7 @@ describe('ApprovalManager.requestHumanDecision', () => {
 
   test('returns approve_once when user selects option 1', async () => {
     const { manager, logs } = makeManager({ responses: ['1'] });
-    const outcome = await manager.requestHumanDecision({ rl, command: { run: 'ls' } });
+    const outcome = await manager.requestHumanDecision({ command: { run: 'ls' } });
     expect(outcome).toEqual({ decision: 'approve_once' });
     expect(logs.success).toContain('Approved (run once).');
   });
@@ -84,7 +82,7 @@ describe('ApprovalManager.requestHumanDecision', () => {
   test('records session approval when user selects option 2', async () => {
     const { manager, logs, approvedCommandRef } = makeManager({ responses: ['2'] });
     const command = { run: 'pwd' };
-    const outcome = await manager.requestHumanDecision({ rl, command });
+    const outcome = await manager.requestHumanDecision({ command });
     expect(outcome).toEqual({ decision: 'approve_session' });
     expect(approvedCommandRef()).toBe(command);
     expect(logs.success).toContain('Approved and added to session approvals.');
@@ -92,14 +90,14 @@ describe('ApprovalManager.requestHumanDecision', () => {
 
   test('returns reject when user selects option 3', async () => {
     const { manager, logs } = makeManager({ responses: ['3'] });
-    const outcome = await manager.requestHumanDecision({ rl, command: { run: 'rm' } });
+    const outcome = await manager.requestHumanDecision({ command: { run: 'rm' } });
     expect(outcome).toEqual({ decision: 'reject', reason: 'human_declined' });
     expect(logs.warn).toContain('Command execution canceled by human (requested alternative).');
   });
 
   test('re-prompts on invalid input until valid choice provided', async () => {
     const { manager, logs } = makeManager({ responses: ['maybe', 'YES'] });
-    const outcome = await manager.requestHumanDecision({ rl, command: { run: 'ls' } });
+    const outcome = await manager.requestHumanDecision({ command: { run: 'ls' } });
     expect(outcome).toEqual({ decision: 'approve_once' });
     expect(logs.warn).toContain('Please enter 1, 2, or 3.');
   });

--- a/tests/unit/escState.test.js
+++ b/tests/unit/escState.test.js
@@ -1,84 +1,32 @@
-import { jest } from '@jest/globals';
-import { ESCAPE_EVENT } from '../../src/cli/io.js';
 import { createEscState, createEscWaiter, resetEscState } from '../../src/agent/escState.js';
 
 describe('createEscState', () => {
-  test('returns noop detach when readline is missing', () => {
-    const { state, detach } = createEscState(null);
-    expect(state).toEqual({ triggered: false, payload: null, waiters: new Set() });
+  test('returns state with trigger and detach', () => {
+    const { state, trigger, detach } = createEscState();
+    expect(state.triggered).toBe(false);
+    expect(typeof trigger).toBe('function');
     expect(typeof detach).toBe('function');
+    trigger('payload');
+    expect(state.triggered).toBe(true);
+    expect(state.payload).toBe('payload');
     expect(() => detach()).not.toThrow();
   });
 
-  test('wires ESC listener and resolves waiters', async () => {
-    const listeners = new Map();
-    const rl = {
-      on: jest.fn((event, handler) => {
-        listeners.set(event, handler);
-      }),
-      off: jest.fn((event, handler) => {
-        if (listeners.get(event) === handler) {
-          listeners.delete(event);
-        }
-      }),
-    };
-
-    const { state, detach } = createEscState(rl);
-
-    expect(rl.on).toHaveBeenCalledTimes(1);
-    const handler = listeners.get(ESCAPE_EVENT);
-    expect(typeof handler).toBe('function');
-
+  test('waiters resolve when trigger invoked', async () => {
+    const { state, trigger } = createEscState();
     const { promise } = createEscWaiter(state);
-    handler('payload');
-
-    await expect(promise).resolves.toBe('payload');
-    expect(state.triggered).toBe(true);
-    expect(state.payload).toBe('payload');
-
-    detach();
-    expect(rl.off).toHaveBeenCalledWith(ESCAPE_EVENT, handler);
-  });
-});
-
-describe('createEscWaiter', () => {
-  test('returns null promise when escState is invalid', () => {
-    const { promise, cleanup } = createEscWaiter(null);
-    expect(promise).toBeNull();
-    expect(typeof cleanup).toBe('function');
-  });
-
-  test('resolves immediately when esc already triggered', async () => {
-    const escState = { triggered: true, payload: 'data' };
-    const { promise } = createEscWaiter(escState);
-    await expect(promise).resolves.toBe('data');
-  });
-
-  test('registers resolver when ESC not triggered yet', async () => {
-    const waiters = new Set();
-    const escState = { triggered: false, payload: null, waiters };
-
-    const { promise, cleanup } = createEscWaiter(escState);
-    expect(waiters.size).toBe(1);
-
-    const resolver = [...waiters][0];
-    resolver('hello');
-
-    await expect(promise).resolves.toBe('hello');
-
-    cleanup();
-    expect(waiters.size).toBe(0);
+    trigger('value');
+    await expect(promise).resolves.toBe('value');
   });
 });
 
 describe('resetEscState', () => {
   test('resets triggered flag and payload', () => {
-    const escState = { triggered: true, payload: 'payload' };
-    resetEscState(escState);
-    expect(escState).toEqual({ triggered: false, payload: null });
-  });
-
-  test('handles invalid input safely', () => {
-    expect(() => resetEscState(null)).not.toThrow();
+    const { state, trigger } = createEscState();
+    trigger('payload');
+    expect(state.triggered).toBe(true);
+    resetEscState(state);
+    expect(state.triggered).toBe(false);
+    expect(state.payload).toBe(null);
   });
 });

--- a/tests/unit/openaiRequest.test.js
+++ b/tests/unit/openaiRequest.test.js
@@ -123,11 +123,11 @@ describe('requestModelCompletion', () => {
     const result = await requestPromise;
 
     expect(result).toEqual({ status: 'canceled' });
-    expect(cancellationHandle.cancel).toHaveBeenCalledWith('esc-key');
+    expect(cancellationHandle.cancel).toHaveBeenCalledWith('ui-cancel');
     expect(cancellationHandle.unregister).toHaveBeenCalledTimes(1);
     expect(observationBuilder.buildCancellationObservation).toHaveBeenCalledWith({
       reason: 'escape_key',
-      message: 'Human pressed ESC to cancel the in-flight request.',
+      message: 'Human canceled the in-flight request.',
       metadata: { esc_payload: 'payload' },
     });
     expect(history).toHaveLength(1);


### PR DESCRIPTION
## Summary
- convert the agent loop into an event-driven runtime that emits structured output events and consumes prompt/cancel inputs
- update the CLI entry point to translate runtime events into terminal output while preserving keyboard cancellation
- introduce an async queue helper and refresh integration/unit tests to drive the new runtime API

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e3a0424a2c83288bada26d47680a49