### PR TITLE
Refactor CLI runtime wiring out of library entry

### DIFF
--- a/context.md
+++ b/context.md
@@ -18,7 +18,7 @@
 ## Key Entry Points
 
 - `index.js`: re-exports the library API from `src/lib/index.js` and forwards direct execution to the CLI runner.
-- `src/lib/index.js`: bootstraps the agent loop, exposes helpers for tests, and provides startup flag utilities (`setStartupFlags`, `applyStartupFlagsFromArgv`).
+- `src/lib/index.js`: aggregates CLI-agnostic helpers, re-exporting the CLI runtime without owning its rendering logic.
 - `src/cli/runner.js`: handles `templates`/`shortcuts` subcommands and wires CLI startup flags before launching the loop.
 - `src/agent/loop.js`: orchestrates OpenAI interactions, now delegating each pass to `passExecutor.js` while managing readline/ESC state.
 - `src/commands/run.js`: sandbox for process execution with timeout + cancellation; re-exports specialised helpers (browse/read/edit/replace/escape-string).
@@ -61,7 +61,7 @@
 
 ## Key Entry Points
 
-- `index.js`: bootstraps the agent loop, handles `templates`/`shortcuts` subcommands, exposes helpers for tests, honours startup flags (`--auto-approve`, `--nohuman`).
+- `index.js`: delegates CLI launches to `src/cli/runner.js`, keeps the library surface re-exported for programmatic consumers.
 - `src/agent/loop.js`: orchestrates OpenAI interactions, now delegating each pass to `passExecutor.js` while managing readline/ESC state.
 - `src/commands/run.js`: sandbox for process execution with timeout + cancellation; re-exports specialised helpers (browse/read/edit/replace/escape-string).
 

--- a/src/cli/context.md
+++ b/src/cli/context.md
@@ -6,6 +6,7 @@
 
 ## Modules
 
+- `runtime.js`: wires the agent runtime to the terminal renderer and exports `agentLoop` plus command tracking helpers used by the CLI entry point.
 - `io.js`: readline wrapper with ESC detection (emits `ESCAPE_EVENT`, cancels active operations, highlights prompts).
 - `render.js`: Markdown-based renderer for plans/messages/command summaries.
 - `thinking.js`: spinner that displays elapsed time while awaiting API responses.

--- a/src/cli/runtime.js
+++ b/src/cli/runtime.js
@@ -1,0 +1,173 @@
+import chalk from 'chalk';
+
+import {
+  getAutoApproveFlag,
+  getNoHumanFlag,
+  setNoHumanFlag,
+} from '../lib/startupFlags.js';
+import { createAgentRuntime } from '../agent/loop.js';
+import { startThinking, stopThinking } from './thinking.js';
+import { createInterface, askHuman, ESCAPE_EVENT } from './io.js';
+import { renderPlan, renderMessage, renderCommand } from './render.js';
+import { renderRemainingContext } from './status.js';
+import {
+  runCommand,
+  runBrowse,
+  runEdit,
+  runRead,
+  runReplace,
+  runEscapeString,
+  runUnescapeString,
+} from '../commands/run.js';
+import {
+  isPreapprovedCommand,
+  isSessionApproved,
+  approveForSession,
+  PREAPPROVED_CFG,
+} from '../commands/preapproval.js';
+import { applyFilter, tailLines } from '../utils/text.js';
+import { incrementCommandCount } from '../commands/commandStats.js';
+
+export async function runCommandAndTrack(run, cwd = '.', timeoutSec = 60) {
+  const result = await runCommand(run, cwd, timeoutSec);
+  try {
+    let key = 'unknown';
+    if (Array.isArray(run) && run.length > 0) key = String(run[0]);
+    else if (typeof run === 'string' && run.trim().length > 0) key = run.trim().split(/\s+/)[0];
+    await incrementCommandCount(key).catch(() => {});
+  } catch (err) {
+    // Ignore stats failures intentionally.
+  }
+  return result;
+}
+
+async function runAgentLoopWithCurrentDependencies() {
+  const runtime = createAgentRuntime({
+    getAutoApproveFlag,
+    getNoHumanFlag,
+    setNoHumanFlag,
+    runCommandFn: runCommand,
+    runBrowseFn: runBrowse,
+    runEditFn: runEdit,
+    runReadFn: runRead,
+    runReplaceFn: runReplace,
+    runEscapeStringFn: runEscapeString,
+    runUnescapeStringFn: runUnescapeString,
+    applyFilterFn: applyFilter,
+    tailLinesFn: tailLines,
+    isPreapprovedCommandFn: isPreapprovedCommand,
+    isSessionApprovedFn: isSessionApproved,
+    approveForSessionFn: approveForSession,
+    preapprovedCfg: PREAPPROVED_CFG,
+  });
+
+  const rl = createInterface();
+  const handleEscape = (payload) => {
+    runtime.cancel({ reason: 'escape-key', payload });
+  };
+  rl.on(ESCAPE_EVENT, handleEscape);
+
+  const outputProcessor = (async () => {
+    for await (const event of runtime.outputs) {
+      if (!event || typeof event !== 'object') continue;
+
+      switch (event.type) {
+        case 'banner':
+          if (event.title) {
+            console.log(chalk.bold.blue(`\n${event.title}`));
+          }
+          if (event.subtitle) {
+            console.log(chalk.dim(event.subtitle));
+          }
+          break;
+        case 'status': {
+          const message = event.message ?? '';
+          if (!message) break;
+          if (event.level === 'warn') {
+            console.log(chalk.yellow(message));
+          } else if (event.level === 'error') {
+            console.log(chalk.red(message));
+          } else if (event.level === 'success') {
+            console.log(chalk.green(message));
+          } else {
+            console.log(message);
+          }
+          if (event.details) {
+            console.log(chalk.dim(String(event.details)));
+          }
+          break;
+        }
+        case 'thinking':
+          if (event.state === 'start') {
+            startThinking();
+          } else {
+            stopThinking();
+          }
+          break;
+        case 'assistant-message':
+          renderMessage(event.message ?? '');
+          break;
+        case 'plan':
+          renderPlan(Array.isArray(event.plan) ? event.plan : []);
+          break;
+        case 'context-usage':
+          if (event.usage) {
+            renderRemainingContext(event.usage);
+          }
+          break;
+        case 'command-result':
+          renderCommand(event.command, event.result, {
+            ...(event.preview || {}),
+            execution: event.execution,
+          });
+          break;
+        case 'error': {
+          const base = event.message || 'Agent error encountered.';
+          console.error(chalk.red(base));
+          if (event.details) {
+            console.error(chalk.dim(String(event.details)));
+          }
+          if (event.raw) {
+            console.error(chalk.dim(String(event.raw)));
+          }
+          break;
+        }
+        case 'request-input': {
+          const prompt = event.prompt ?? '\n ▷ ';
+          const answer = await askHuman(rl, prompt);
+          runtime.submitPrompt(answer);
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  })();
+
+  let outputError = null;
+  try {
+    await runtime.start();
+  } finally {
+    rl.off?.(ESCAPE_EVENT, handleEscape);
+    rl.close?.();
+    stopThinking();
+    try {
+      await outputProcessor;
+    } catch (err) {
+      outputError = err;
+    }
+  }
+
+  if (outputError) {
+    throw outputError;
+  }
+}
+
+export async function agentLoop() {
+  return runAgentLoopWithCurrentDependencies();
+}
+
+export default {
+  agentLoop,
+  runCommandAndTrack,
+};

--- a/src/lib/context.md
+++ b/src/lib/context.md
@@ -6,9 +6,10 @@
 
 ## Modules
 
-- `index.js`: re-exports command runners, prompt helpers, and startup flag utilities while wiring the agent loop used by the CLI.
+- `index.js`: re-exports command runners, prompt helpers, and startup flag utilities without owning CLI rendering concerns.
+- `startupFlags.js`: centralises mutable startup flag state so the CLI runtime and library exports stay in sync.
 
 ## Notes
 
 - Startup flags default to `false` and can be configured via `setStartupFlags`, `parseStartupFlagsFromArgv`, or `applyStartupFlagsFromArgv`.
-- The CLI runner (`../cli/runner.js`) is the only module responsible for parsing process arguments and invoking `agentLoop()`.
+- The CLI runner (`../cli/runner.js`) is the only module responsible for parsing process arguments and invoking the CLI runtime.

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -2,21 +2,15 @@
  * Aggregated library entry for the OpenAgent runtime.
  *
  * Responsibilities:
- * - Wire modular subsystems for OpenAI access, rendering, command execution, and approval flow.
- * - Provide the aggregate export surface that tests exercise for individual helpers.
- * - Expose helpers that the CLI runner can consume without forcing consumers to import CLI glue.
- *
- * Collaborators:
- * - `src/agent/loop.js` drives the interactive conversation flow.
- * - `src/openai/client.js` manages the memoized OpenAI client and model metadata.
- * - `src/commands`, `src/cli`, and `src/config` supply focused utilities that the loop depends upon.
+ * - Provide a CLI-agnostic export surface for package consumers.
+ * - Re-export CLI utilities without entangling the runtime wiring logic.
+ * - Surface helpers that the CLI runner can consume without forcing consumers to
+ *   import CLI glue manually.
  */
 
 import 'dotenv/config';
 
-import chalk from 'chalk';
-
-import { getOpenAIClient, resetOpenAIClient, MODEL } from '../openai/client.js';
+import { MODEL, getOpenAIClient, resetOpenAIClient } from '../openai/client.js';
 import { startThinking, stopThinking, formatElapsedTime } from '../cli/thinking.js';
 import { createInterface, askHuman, ESCAPE_EVENT } from '../cli/io.js';
 import {
@@ -56,267 +50,13 @@ import {
 import { createAgentLoop, createAgentRuntime, extractResponseText } from '../agent/loop.js';
 import { loadTemplates, renderTemplateCommand, handleTemplatesCli } from '../templates/cli.js';
 import { loadShortcutsFile, findShortcut, handleShortcutsCli } from '../shortcuts/cli.js';
-import { incrementCommandCount } from '../commands/commandStats.js';
-
-/**
- * Flags derived from CLI usage (auto-approve, headless). They default to `false`
- * for library consumers and can be configured through `setStartupFlags`,
- * `parseStartupFlagsFromArgv`, or `applyStartupFlagsFromArgv`.
- */
-let startupForceAutoApprove = false;
-let startupNoHuman = false;
-
-function getAutoApproveFlag() {
-  return startupForceAutoApprove;
-}
-
-function getNoHumanFlag() {
-  return startupNoHuman;
-}
-
-function setNoHumanFlag(value) {
-  startupNoHuman = Boolean(value);
-}
-
-export function setStartupFlags({ forceAutoApprove = false, noHuman = false } = {}) {
-  startupForceAutoApprove = Boolean(forceAutoApprove);
-  startupNoHuman = Boolean(noHuman);
-}
-
-export function parseStartupFlagsFromArgv(argv = process.argv) {
-  const positional = Array.isArray(argv) ? argv.slice(2) : [];
-  let forceAutoApprove = false;
-  let noHuman = false;
-
-  for (const arg of positional) {
-    if (!arg) continue;
-    const normalized = String(arg).trim().toLowerCase();
-    if (
-      normalized === 'auto' ||
-      normalized === '--auto' ||
-      normalized === '--auto-approve' ||
-      normalized === '--auto-approval'
-    ) {
-      forceAutoApprove = true;
-    }
-
-    if (normalized === 'nohuman' || normalized === '--nohuman' || normalized === '--no-human') {
-      noHuman = true;
-    }
-  }
-
-  return { forceAutoApprove, noHuman };
-}
-
-export function applyStartupFlagsFromArgv(argv = process.argv) {
-  const flags = parseStartupFlagsFromArgv(argv);
-  setStartupFlags(flags);
-  return flags;
-}
-
-export async function runCommandAndTrack(run, cwd = '.', timeoutSec = 60) {
-  const result = await runCommand(run, cwd, timeoutSec);
-  try {
-    let key = 'unknown';
-    if (Array.isArray(run) && run.length > 0) key = String(run[0]);
-    else if (typeof run === 'string' && run.trim().length > 0) key = run.trim().split(/\s+/)[0];
-    await incrementCommandCount(key).catch(() => {});
-  } catch (err) {
-    // Ignore stats failures intentionally.
-  }
-  return result;
-}
-
-async function runAgentLoopWithCurrentDependencies() {
-  const runtime = createAgentRuntime({
-    getAutoApproveFlag,
-    getNoHumanFlag,
-    setNoHumanFlag,
-    runCommandFn: runCommand,
-    runBrowseFn: runBrowse,
-    runEditFn: runEdit,
-    runReadFn: runRead,
-    runReplaceFn: runReplace,
-    runEscapeStringFn: runEscapeString,
-    runUnescapeStringFn: runUnescapeString,
-    applyFilterFn: applyFilter,
-    tailLinesFn: tailLines,
-    isPreapprovedCommandFn: isPreapprovedCommand,
-    isSessionApprovedFn: isSessionApproved,
-    approveForSessionFn: approveForSession,
-    preapprovedCfg: PREAPPROVED_CFG,
-  });
-
-  const rl = createInterface();
-  const handleEscape = (payload) => {
-    runtime.cancel({ reason: 'escape-key', payload });
-  };
-  rl.on(ESCAPE_EVENT, handleEscape);
-
-  const outputProcessor = (async () => {
-    for await (const event of runtime.outputs) {
-      if (!event || typeof event !== 'object') continue;
-
-      switch (event.type) {
-        case 'banner':
-          if (event.title) {
-            console.log(chalk.bold.blue(`\n${event.title}`));
-          }
-          if (event.subtitle) {
-            console.log(chalk.dim(event.subtitle));
-          }
-          break;
-        case 'status': {
-          const message = event.message ?? '';
-          if (!message) break;
-          if (event.level === 'warn') {
-            console.log(chalk.yellow(message));
-          } else if (event.level === 'error') {
-            console.log(chalk.red(message));
-          } else if (event.level === 'success') {
-            console.log(chalk.green(message));
-          } else {
-            console.log(message);
-          }
-          if (event.details) {
-            console.log(chalk.dim(String(event.details)));
-          }
-          break;
-        }
-        case 'thinking':
-          if (event.state === 'start') {
-            startThinking();
-          } else {
-            stopThinking();
-          }
-          break;
-        case 'assistant-message':
-          renderMessage(event.message ?? '');
-          break;
-        case 'plan':
-          renderPlan(Array.isArray(event.plan) ? event.plan : []);
-          break;
-        case 'context-usage':
-          if (event.usage) {
-            renderRemainingContext(event.usage);
-          }
-          break;
-        case 'command-result':
-          renderCommand(event.command, event.result, {
-            ...(event.preview || {}),
-            execution: event.execution,
-          });
-          break;
-        case 'error': {
-          const base = event.message || 'Agent error encountered.';
-          console.error(chalk.red(base));
-          if (event.details) {
-            console.error(chalk.dim(String(event.details)));
-          }
-          if (event.raw) {
-            console.error(chalk.dim(String(event.raw)));
-          }
-          break;
-        }
-        case 'request-input': {
-          const prompt = event.prompt ?? '\n ▷ ';
-          const answer = await askHuman(rl, prompt);
-          runtime.submitPrompt(answer);
-          break;
-        }
-        default:
-          break;
-      }
-    }
-  })();
-
-  let outputError = null;
-  try {
-    await runtime.start();
-  } finally {
-    rl.off?.(ESCAPE_EVENT, handleEscape);
-    rl.close?.();
-    stopThinking();
-    try {
-      await outputProcessor;
-    } catch (err) {
-      outputError = err;
-    }
-  }
-
-  if (outputError) {
-    throw outputError;
-  }
-}
-
-export async function agentLoop() {
-  return runAgentLoopWithCurrentDependencies();
-}
-
-const exported = {
-  get STARTUP_FORCE_AUTO_APPROVE() {
-    return startupForceAutoApprove;
-  },
-  set STARTUP_FORCE_AUTO_APPROVE(value) {
-    startupForceAutoApprove = Boolean(value);
-  },
-  get STARTUP_NO_HUMAN() {
-    return startupNoHuman;
-  },
-  set STARTUP_NO_HUMAN(value) {
-    startupNoHuman = Boolean(value);
-  },
-  MODEL,
-  getOpenAIClient,
-  resetOpenAIClient,
-  startThinking,
-  stopThinking,
-  formatElapsedTime,
-  findAgentFiles,
-  buildAgentsPrompt,
-  BASE_SYSTEM_PROMPT,
-  SYSTEM_PROMPT,
-  runCommand,
-  runBrowse,
-  runEdit,
-  runRead,
-  runReplace,
-  runEscapeString,
-  runUnescapeString,
-  applyFilter,
-  tailLines,
-  shellSplit,
-  display,
-  wrapStructuredContent,
-  renderMarkdownMessage,
-  renderPlan,
-  renderRemainingContext,
-  createInterface,
-  askHuman,
-  renderMessage,
-  renderCommand,
-  loadPreapprovedConfig,
-  isPreapprovedCommand,
-  __commandSignature,
-  isSessionApproved,
-  approveForSession,
-  resetSessionApprovals,
-  extractResponseText,
-  createAgentLoop,
-  createAgentRuntime,
-  PREAPPROVED_CFG,
-  loadTemplates,
-  renderTemplateCommand,
-  loadShortcutsFile,
-  findShortcut,
-  runCommandAndTrack,
-  agentLoop,
+import {
   setStartupFlags,
   parseStartupFlagsFromArgv,
   applyStartupFlagsFromArgv,
-  handleTemplatesCli,
-  handleShortcutsCli,
-};
+  startupFlagAccessors,
+} from './startupFlags.js';
+import { runCommandAndTrack, agentLoop } from '../cli/runtime.js';
 
 export {
   MODEL,
@@ -325,10 +65,16 @@ export {
   startThinking,
   stopThinking,
   formatElapsedTime,
-  findAgentFiles,
-  buildAgentsPrompt,
-  BASE_SYSTEM_PROMPT,
-  SYSTEM_PROMPT,
+  createInterface,
+  askHuman,
+  ESCAPE_EVENT,
+  display,
+  wrapStructuredContent,
+  renderMarkdownMessage,
+  renderPlan,
+  renderMessage,
+  renderCommand,
+  renderRemainingContext,
   runCommand,
   runBrowse,
   runEdit,
@@ -336,34 +82,89 @@ export {
   runReplace,
   runEscapeString,
   runUnescapeString,
+  loadPreapprovedConfig,
+  isPreapprovedCommand,
+  isSessionApproved,
+  approveForSession,
+  resetSessionApprovals,
+  __commandSignature,
+  PREAPPROVED_CFG,
   applyFilter,
   tailLines,
   shellSplit,
+  findAgentFiles,
+  buildAgentsPrompt,
+  BASE_SYSTEM_PROMPT,
+  SYSTEM_PROMPT,
+  createAgentLoop,
+  createAgentRuntime,
+  extractResponseText,
+  loadTemplates,
+  renderTemplateCommand,
+  handleTemplatesCli,
+  loadShortcutsFile,
+  findShortcut,
+  handleShortcutsCli,
+  setStartupFlags,
+  parseStartupFlagsFromArgv,
+  applyStartupFlagsFromArgv,
+  runCommandAndTrack,
+  agentLoop,
+};
+
+const exported = {
+  ...startupFlagAccessors,
+  MODEL,
+  getOpenAIClient,
+  resetOpenAIClient,
+  startThinking,
+  stopThinking,
+  formatElapsedTime,
+  createInterface,
+  askHuman,
+  ESCAPE_EVENT,
   display,
   wrapStructuredContent,
   renderMarkdownMessage,
   renderPlan,
-  renderRemainingContext,
-  createInterface,
-  askHuman,
   renderMessage,
   renderCommand,
+  renderRemainingContext,
+  runCommand,
+  runBrowse,
+  runEdit,
+  runRead,
+  runReplace,
+  runEscapeString,
+  runUnescapeString,
   loadPreapprovedConfig,
   isPreapprovedCommand,
-  __commandSignature,
   isSessionApproved,
   approveForSession,
   resetSessionApprovals,
-  extractResponseText,
+  __commandSignature,
+  PREAPPROVED_CFG,
+  applyFilter,
+  tailLines,
+  shellSplit,
+  findAgentFiles,
+  buildAgentsPrompt,
+  BASE_SYSTEM_PROMPT,
+  SYSTEM_PROMPT,
   createAgentLoop,
   createAgentRuntime,
-  PREAPPROVED_CFG,
+  extractResponseText,
   loadTemplates,
   renderTemplateCommand,
+  handleTemplatesCli,
   loadShortcutsFile,
   findShortcut,
-  handleTemplatesCli,
   handleShortcutsCli,
+  setStartupFlags,
+  parseStartupFlagsFromArgv,
+  applyStartupFlagsFromArgv,
+  runCommandAndTrack,
+  agentLoop,
 };
 
 export default exported;

--- a/src/lib/startupFlags.js
+++ b/src/lib/startupFlags.js
@@ -1,0 +1,80 @@
+/**
+ * Internal state and helpers for startup flags shared between the CLI runner
+ * and library consumers.
+ */
+
+let startupForceAutoApprove = false;
+let startupNoHuman = false;
+
+export function getAutoApproveFlag() {
+  return startupForceAutoApprove;
+}
+
+export function getNoHumanFlag() {
+  return startupNoHuman;
+}
+
+export function setNoHumanFlag(value) {
+  startupNoHuman = Boolean(value);
+}
+
+export function setStartupFlags({ forceAutoApprove = false, noHuman = false } = {}) {
+  startupForceAutoApprove = Boolean(forceAutoApprove);
+  startupNoHuman = Boolean(noHuman);
+}
+
+export function parseStartupFlagsFromArgv(argv = process.argv) {
+  const positional = Array.isArray(argv) ? argv.slice(2) : [];
+  let forceAutoApprove = false;
+  let noHuman = false;
+
+  for (const arg of positional) {
+    if (!arg) continue;
+    const normalized = String(arg).trim().toLowerCase();
+    if (
+      normalized === 'auto' ||
+      normalized === '--auto' ||
+      normalized === '--auto-approve' ||
+      normalized === '--auto-approval'
+    ) {
+      forceAutoApprove = true;
+    }
+
+    if (normalized === 'nohuman' || normalized === '--nohuman' || normalized === '--no-human') {
+      noHuman = true;
+    }
+  }
+
+  return { forceAutoApprove, noHuman };
+}
+
+export function applyStartupFlagsFromArgv(argv = process.argv) {
+  const flags = parseStartupFlagsFromArgv(argv);
+  setStartupFlags(flags);
+  return flags;
+}
+
+export const startupFlagAccessors = {
+  get STARTUP_FORCE_AUTO_APPROVE() {
+    return startupForceAutoApprove;
+  },
+  set STARTUP_FORCE_AUTO_APPROVE(value) {
+    startupForceAutoApprove = Boolean(value);
+  },
+  get STARTUP_NO_HUMAN() {
+    return startupNoHuman;
+  },
+  set STARTUP_NO_HUMAN(value) {
+    startupNoHuman = Boolean(value);
+  },
+};
+
+export default {
+  getAutoApproveFlag,
+  getNoHumanFlag,
+  setNoHumanFlag,
+  setStartupFlags,
+  parseStartupFlagsFromArgv,
+  applyStartupFlagsFromArgv,
+  startupFlagAccessors,
+};


### PR DESCRIPTION
## Summary
- move the CLI agent loop and command tracking into a dedicated src/cli/runtime.js module
- centralize startup flag state in src/lib/startupFlags.js and keep src/lib/index.js CLI-agnostic
- refresh context docs to describe the new separation of responsibilities

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e3bd381f0c8328bcc2ef17b076ed96