### PR TITLE
Update CLI spinner to braille animation

### DIFF
--- a/src/cli/thinking.js
+++ b/src/cli/thinking.js
@@ -30,7 +30,9 @@ export function formatElapsedTime(startTime, now = Date.now()) {
 export function startThinking() {
   if (intervalHandle) return;
   animationStart = Date.now();
-  const frames = ['Thinking.  ', 'Thinking.. ', 'Thinking...'];
+  // Unicode braille spinner frames requested for the waiting animation.
+  const frames = ['⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏', '⠋'];
+  const label = ' Thinking';
   let i = 0;
   process.stdout.write('\n');
   intervalHandle = setInterval(() => {
@@ -38,7 +40,7 @@ export function startThinking() {
       const elapsed = formatElapsedTime(animationStart);
       readline.clearLine(process.stdout, 0);
       readline.cursorTo(process.stdout, 0);
-      process.stdout.write(chalk.dim(frames[i] + ' (' + elapsed + ')'));
+      process.stdout.write(chalk.dim(frames[i] + label + ' (' + elapsed + ')'));
       i = (i + 1) % frames.length;
     } catch (err) {
       // Ignore TTY issues silently.


### PR DESCRIPTION
## Summary
- switch the CLI thinking animation to the requested braille spinner frames
- keep the "Thinking" label alongside the spinner while updating elapsed time formatting

## Testing
- npm test -- --runTestsByPath tests/unit/openaiRequest.test.js tests/unit/handshake.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3cae35a3883288f6ba65c1251c606