### PR TITLE
Refine command handler architecture into classes

### DIFF
--- a/src/agent/commands/BrowseCommand.js
+++ b/src/agent/commands/BrowseCommand.js
@@ -1,0 +1,35 @@
+/**
+ * Opens URLs through the browsing subsystem.
+ */
+export default class BrowseCommand {
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  isMatch(context) {
+    return context.runKeyword === 'browse';
+  }
+
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  async execute(context) {
+    const { runTokens, timeout, runBrowseFn } = context;
+    const target = runTokens.slice(1).join(' ').trim();
+
+    if (!target) {
+      return {
+        result: this.#buildErrorResult('browse command requires a URL argument'),
+        executionDetails: { type: 'BROWSE', target: '' },
+      };
+    }
+
+    const result = await runBrowseFn(target, timeout);
+    return { result, executionDetails: { type: 'BROWSE', target } };
+  }
+
+  #buildErrorResult(message) {
+    return {
+      stdout: '',
+      stderr: message,
+      exit_code: 1,
+      killed: false,
+      runtime_ms: 0,
+    };
+  }
+}

--- a/src/agent/commands/EditCommand.js
+++ b/src/agent/commands/EditCommand.js
@@ -1,0 +1,20 @@
+/**
+ * Handles structured edit commands emitted by the model.
+ */
+export default class EditCommand {
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  isMatch(context) {
+    return Boolean(context.command.edit);
+  }
+
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  async execute(context) {
+    const { command, cwd, runEditFn } = context;
+    const result = await runEditFn(command.edit, cwd);
+
+    return {
+      result,
+      executionDetails: { type: 'EDIT', spec: command.edit },
+    };
+  }
+}

--- a/src/agent/commands/EscapeStringCommand.js
+++ b/src/agent/commands/EscapeStringCommand.js
@@ -1,0 +1,20 @@
+/**
+ * Escapes strings via the dedicated helper to avoid shell quoting mistakes.
+ */
+export default class EscapeStringCommand {
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  isMatch(context) {
+    return Boolean(context.command.escape_string);
+  }
+
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  async execute(context) {
+    const { command, cwd, runEscapeStringFn } = context;
+    const result = await runEscapeStringFn(command.escape_string, cwd);
+
+    return {
+      result,
+      executionDetails: { type: 'ESCAPE_STRING', spec: command.escape_string },
+    };
+  }
+}

--- a/src/agent/commands/ExecuteCommand.js
+++ b/src/agent/commands/ExecuteCommand.js
@@ -1,0 +1,20 @@
+/**
+ * Default command runner that shells out when no other handler matches.
+ */
+export default class ExecuteCommand {
+  /** @param {import('../commandExecution.js').AgentCommandContext} _context */
+  isMatch(_context) {
+    return true;
+  }
+
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  async execute(context) {
+    const { command, cwd, timeout, runCommandFn } = context;
+    const result = await runCommandFn(command.run, cwd, timeout, command.shell);
+
+    return {
+      result,
+      executionDetails: { type: 'EXECUTE', command },
+    };
+  }
+}

--- a/src/agent/commands/ReadCommand.js
+++ b/src/agent/commands/ReadCommand.js
@@ -1,0 +1,45 @@
+import { parseReadSpecTokens, mergeReadSpecs } from '../../commands/readSpec.js';
+
+/**
+ * Reads file content based on structured specs or inline tokens.
+ */
+export default class ReadCommand {
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  isMatch(context) {
+    return context.runKeyword === 'read' || Boolean(context.command.read);
+  }
+
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  async execute(context) {
+    const { runKeyword, runTokens, command, cwd, runReadFn } = context;
+    const tokenSpec = runKeyword === 'read' ? parseReadSpecTokens(runTokens.slice(1)) : {};
+    const baseSpec =
+      command.read && typeof command.read === 'object'
+        ? command.read
+        : {};
+
+    const mergedSpec = mergeReadSpecs(baseSpec, tokenSpec);
+    if (!mergedSpec.path) {
+      return {
+        result: this.#buildErrorResult('read command requires a path argument'),
+        executionDetails: { type: 'READ', spec: mergedSpec },
+      };
+    }
+
+    const result = await runReadFn(mergedSpec, cwd);
+    return {
+      result,
+      executionDetails: { type: 'READ', spec: mergedSpec },
+    };
+  }
+
+  #buildErrorResult(message) {
+    return {
+      stdout: '',
+      stderr: message,
+      exit_code: 1,
+      killed: false,
+      runtime_ms: 0,
+    };
+  }
+}

--- a/src/agent/commands/ReplaceCommand.js
+++ b/src/agent/commands/ReplaceCommand.js
@@ -1,0 +1,20 @@
+/**
+ * Applies structured replacements across files.
+ */
+export default class ReplaceCommand {
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  isMatch(context) {
+    return Boolean(context.command.replace);
+  }
+
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  async execute(context) {
+    const { command, cwd, runReplaceFn } = context;
+    const result = await runReplaceFn(command.replace, cwd);
+
+    return {
+      result,
+      executionDetails: { type: 'REPLACE', spec: command.replace },
+    };
+  }
+}

--- a/src/agent/commands/UnescapeStringCommand.js
+++ b/src/agent/commands/UnescapeStringCommand.js
@@ -1,0 +1,20 @@
+/**
+ * Restores escaped strings back to their literal form.
+ */
+export default class UnescapeStringCommand {
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  isMatch(context) {
+    return Boolean(context.command.unescape_string);
+  }
+
+  /** @param {import('../commandExecution.js').AgentCommandContext} context */
+  async execute(context) {
+    const { command, cwd, runUnescapeStringFn } = context;
+    const result = await runUnescapeStringFn(command.unescape_string, cwd);
+
+    return {
+      result,
+      executionDetails: { type: 'UNESCAPE_STRING', spec: command.unescape_string },
+    };
+  }
+}

--- a/src/agent/commands/context.md
+++ b/src/agent/commands/context.md
@@ -1,0 +1,19 @@
+# Directory Context: src/agent/commands
+
+## Purpose
+
+- Houses class-based implementations of the `ICommand` contract used by `commandExecution.js`.
+
+## Key Files
+
+- `BrowseCommand.js`: opens URLs using the browsing runner with validation.
+- `EditCommand.js`: wraps structured `edit` payloads.
+- `EscapeStringCommand.js` / `UnescapeStringCommand.js`: proxy string transformation helpers.
+- `ReadCommand.js`: merges inline token specs with structured read payloads before dispatch.
+- `ReplaceCommand.js`: applies structured text replacements.
+- `ExecuteCommand.js`: default shell execution fallback when no other command matches.
+
+## Notes
+
+- Each class is stateless; instances are recreated on every invocation for clarity.
+- Tests continue to exercise behaviour through `executeAgentCommand` to keep the handler pipeline black-boxed.

--- a/src/agent/context.md
+++ b/src/agent/context.md
@@ -12,7 +12,8 @@
 - `escState.js`: centralises cancellation state, allowing UI-triggered events to notify in-flight operations.
 - `passExecutor.js`: performs an agent pass (OpenAI request, JSON parsing, plan updates, approvals, command execution, observation logging).
 - `historyCompactor.js`: auto-compacts older history entries when context usage exceeds the configured threshold by summarizing them into long-term memory snapshots.
-- `commandExecution.js`: routes assistant commands to the correct runner (edit/read/browse/escape/etc.) and ensures built-ins are interpreted before falling back to shell execution.
+- `commandExecution.js`: routes assistant commands to the correct runner (edit/read/browse/escape/etc.) through dedicated handler classes so built-ins are interpreted before falling back to shell execution.
+- `commands/`: concrete command handler classes implementing the shared `ICommand` contract used by `commandExecution.js`.
 - `openaiRequest.js`: wraps the OpenAI SDK call, wiring ESC cancellation, request aborts, and observation recording into a single surface.
 - `observationBuilder.js`: normalises command results into CLI previews and LLM observations so the conversation history remains consistent.
 


### PR DESCRIPTION
## Summary
- define an ICommand contract for agent commands and document the execution context
- implement the command handlers as dedicated classes within src/agent/commands and wire them into commandExecution
- update agent context docs to mention the class-based handler directory

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e3cf97dc0c8328b65cd1ffa6eafdb4