### PR TITLE
Add WebSocket UI binding for agent runtime

### DIFF
--- a/src/context.md
+++ b/src/context.md
@@ -14,6 +14,7 @@
 - `config/`: system prompt discovery and workspace metadata.
 - `openai/`: memoized OpenAI client factory.
 - `shortcuts/`, `templates/`: CLI facades for auxiliary commands.
+- `ui/`: transport-agnostic UI bindings (e.g., WebSocket adapters) for the runtime.
 - `utils/`: cancellation manager, text helpers, output combiner.
 
 ## Positive Signals

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -50,6 +50,7 @@ import {
 import { createAgentLoop, createAgentRuntime, extractResponseText } from '../agent/loop.js';
 import { loadTemplates, renderTemplateCommand, handleTemplatesCli } from '../templates/cli.js';
 import { loadShortcutsFile, findShortcut, handleShortcutsCli } from '../shortcuts/cli.js';
+import { createWebSocketUi } from '../ui/websocket.js';
 import {
   setStartupFlags,
   parseStartupFlagsFromArgv,
@@ -99,6 +100,7 @@ export {
   createAgentLoop,
   createAgentRuntime,
   extractResponseText,
+  createWebSocketUi,
   loadTemplates,
   renderTemplateCommand,
   handleTemplatesCli,
@@ -154,6 +156,7 @@ const exported = {
   createAgentLoop,
   createAgentRuntime,
   extractResponseText,
+  createWebSocketUi,
   loadTemplates,
   renderTemplateCommand,
   handleTemplatesCli,

--- a/src/ui/context.md
+++ b/src/ui/context.md
@@ -1,0 +1,17 @@
+# Directory Context: src/ui
+
+## Purpose
+
+- Houses UI bindings that connect the agent runtime to transport layers other than the CLI.
+- Provides adapters that translate socket or web events into agent input queues and forward agent output events back to clients.
+
+## Notes
+
+- Modules here should remain framework-agnostic and accept dependency injection hooks for testing.
+- Keep bindings resilient to differing event emitter APIs (`on`/`off` vs `addEventListener`/`removeEventListener`).
+- Avoid bundling transport-specific dependencies; expect callers to supply compatible socket instances.
+
+## Related Context
+
+- Core runtime emitting events: [`../agent/context.md`](../agent/context.md)
+- CLI-oriented binding for comparison: [`../cli/context.md`](../cli/context.md)

--- a/src/ui/websocket.js
+++ b/src/ui/websocket.js
@@ -1,0 +1,372 @@
+/**
+ * WebSocket UI binding for the agent runtime.
+ *
+ * Translates incoming WebSocket messages into agent prompts/cancellation
+ * events and streams runtime output events back over the socket as JSON.
+ */
+import { createAgentRuntime } from '../agent/loop.js';
+
+const textDecoder = typeof TextDecoder !== 'undefined' ? new TextDecoder() : null;
+
+function decodeBinary(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer?.(value)) {
+    return value.toString('utf8');
+  }
+
+  if (typeof ArrayBuffer !== 'undefined') {
+    if (value instanceof ArrayBuffer) {
+      if (textDecoder) {
+        return textDecoder.decode(new Uint8Array(value));
+      }
+      return String.fromCharCode(...new Uint8Array(value));
+    }
+    if (ArrayBuffer.isView?.(value)) {
+      if (textDecoder) {
+        return textDecoder.decode(value);
+      }
+      return String.fromCharCode(...value);
+    }
+  }
+
+  return null;
+}
+
+function unwrapSocketMessage(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return raw;
+  }
+
+  if (typeof raw.data !== 'undefined') {
+    return unwrapSocketMessage(raw.data);
+  }
+
+  if (Array.isArray(raw) && raw.length === 1) {
+    return unwrapSocketMessage(raw[0]);
+  }
+
+  return raw;
+}
+
+function defaultParseIncoming(raw) {
+  const value = unwrapSocketMessage(raw);
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return { type: 'prompt', prompt: '' };
+    }
+    try {
+      const parsed = JSON.parse(value);
+      return parsed;
+    } catch {
+      return { type: 'prompt', prompt: value };
+    }
+  }
+
+  const decoded = decodeBinary(value);
+  if (typeof decoded === 'string') {
+    return defaultParseIncoming(decoded);
+  }
+
+  return value;
+}
+
+function defaultFormatOutgoing(event) {
+  return JSON.stringify(event ?? {});
+}
+
+function normalisePromptValue(value) {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  return String(value);
+}
+
+function attachListener(socket, event, handler) {
+  if (typeof socket.on === 'function') {
+    socket.on(event, handler);
+    return () => {
+      if (typeof socket.off === 'function') {
+        socket.off(event, handler);
+      } else if (typeof socket.removeListener === 'function') {
+        socket.removeListener(event, handler);
+      } else if (typeof socket.removeEventListener === 'function') {
+        socket.removeEventListener(event, handler);
+      }
+    };
+  }
+
+  if (typeof socket.addEventListener === 'function') {
+    socket.addEventListener(event, handler);
+    return () => socket.removeEventListener?.(event, handler);
+  }
+
+  throw new Error('Socket must support on/off or addEventListener/removeEventListener.');
+}
+
+async function safeSend(socket, formatter, event, { suppressErrors = false } = {}) {
+  if (!socket || typeof socket.send !== 'function') return false;
+
+  let payload;
+  try {
+    payload = formatter(event);
+  } catch (error) {
+    if (!suppressErrors) {
+      console.error('[openagent:websocket-ui] Failed to format outgoing event:', error);
+    }
+    return false;
+  }
+
+  if (typeof payload === 'undefined') {
+    return false;
+  }
+
+  try {
+    const result = socket.send(payload);
+    if (result && typeof result.then === 'function') {
+      await result;
+    }
+    return true;
+  } catch (error) {
+    if (!suppressErrors) {
+      console.error('[openagent:websocket-ui] Failed to send runtime event to socket:', error);
+    }
+    return false;
+  }
+}
+
+export function createWebSocketUi({
+  socket,
+  runtimeOptions = {},
+  createRuntime = createAgentRuntime,
+  parseIncoming = defaultParseIncoming,
+  formatOutgoing = defaultFormatOutgoing,
+  autoStart = true,
+  cancelOnDisconnect = true,
+} = {}) {
+  if (!socket || typeof socket !== 'object') {
+    throw new Error('createWebSocketUi requires a WebSocket-like socket instance.');
+  }
+  if (typeof socket.send !== 'function') {
+    throw new Error('Provided socket must implement send().');
+  }
+
+  const runtime = createRuntime(runtimeOptions);
+  const detachFns = [];
+  let started = false;
+  let closed = false;
+  let startPromise = null;
+  let stopPromise = null;
+  let pumpPromise = null;
+
+  const detachAll = () => {
+    while (detachFns.length > 0) {
+      const detach = detachFns.shift();
+      try {
+        detach?.();
+      } catch {
+        // Ignore listener cleanup failures.
+      }
+    }
+  };
+
+  const handleMessage = (...args) => {
+    if (closed) return;
+
+    let parsed;
+    try {
+      parsed = parseIncoming(args.length <= 1 ? args[0] : args);
+    } catch (error) {
+      void safeSend(
+        socket,
+        formatOutgoing,
+        {
+          type: 'error',
+          message: 'Failed to parse incoming WebSocket message.',
+          details: error instanceof Error ? error.message : String(error),
+        },
+        { suppressErrors: true },
+      );
+      return;
+    }
+
+    if (parsed == null) {
+      return;
+    }
+
+    if (typeof parsed === 'string') {
+      runtime.submitPrompt(parsed);
+      return;
+    }
+
+    if (typeof parsed !== 'object') {
+      runtime.submitPrompt(String(parsed));
+      return;
+    }
+
+    const type = typeof parsed.type === 'string' ? parsed.type : undefined;
+
+    if (type === 'cancel' || parsed.cancel === true) {
+      runtime.cancel(parsed.payload ?? { reason: 'socket-cancel' });
+      return;
+    }
+
+    const promptValue = parsed.prompt ?? parsed.value ?? parsed.message;
+
+    if (
+      type === 'prompt' ||
+      type === 'input' ||
+      type === 'message' ||
+      type === 'user-input' ||
+      typeof promptValue !== 'undefined'
+    ) {
+      runtime.submitPrompt(normalisePromptValue(promptValue));
+    }
+  };
+
+  const handleClose = () => {
+    void stop({ reason: 'socket-close', cancel: cancelOnDisconnect });
+  };
+
+  const handleError = (error) => {
+    if (closed) return;
+    console.error('[openagent:websocket-ui] Socket error encountered:', error);
+    void stop({ reason: 'socket-error', cancel: cancelOnDisconnect });
+  };
+
+  try {
+    detachFns.push(attachListener(socket, 'message', handleMessage));
+  } catch (error) {
+    throw new Error(`Failed to attach WebSocket message listener: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  try {
+    detachFns.push(attachListener(socket, 'close', handleClose));
+  } catch {
+    // Some sockets (e.g., minimal mocks) may not expose close events; ignore.
+  }
+
+  try {
+    detachFns.push(attachListener(socket, 'error', handleError));
+  } catch {
+    // Optional; not all implementations expose an error event.
+  }
+
+  async function pumpOutputs() {
+    const iterable =
+      runtime.outputs?.[Symbol.asyncIterator]?.() ??
+      (typeof runtime.outputs?.next === 'function'
+        ? {
+            async *[Symbol.asyncIterator]() {
+              while (true) {
+                // eslint-disable-next-line no-await-in-loop
+                const value = await runtime.outputs.next();
+                if (value === undefined || value === null) {
+                  continue;
+                }
+                yield value;
+              }
+            },
+          }[Symbol.asyncIterator]()
+        : null);
+
+    if (!iterable) {
+      return;
+    }
+
+    try {
+      for await (const event of iterable) {
+        if (closed) break;
+        if (!event || typeof event !== 'object') continue;
+        await safeSend(socket, formatOutgoing, event);
+      }
+    } catch (error) {
+      if (!closed) {
+        await safeSend(
+          socket,
+          formatOutgoing,
+          {
+            type: 'error',
+            message: 'WebSocket UI failed to forward agent event.',
+            details: error instanceof Error ? error.message : String(error),
+          },
+          { suppressErrors: true },
+        );
+      }
+      throw error;
+    }
+  }
+
+  async function stop({ reason = 'manual-stop', cancel = cancelOnDisconnect } = {}) {
+    if (stopPromise) {
+      return stopPromise;
+    }
+
+    closed = true;
+    detachAll();
+
+    if (cancel) {
+      try {
+        runtime.cancel({ reason });
+      } catch {
+        // Ignore cancellation failures; runtime may already be closed.
+      }
+    }
+
+    try {
+      runtime.outputs?.close?.();
+    } catch {
+      // Ignore close failures on custom queues.
+    }
+
+    stopPromise = (async () => {
+      try {
+        await pumpPromise?.catch(() => {});
+      } finally {
+        // no-op placeholder for future cleanup hooks
+      }
+    })();
+
+    return stopPromise;
+  }
+
+  async function start() {
+    if (startPromise) {
+      return startPromise;
+    }
+    if (started) {
+      throw new Error('WebSocket UI already started.');
+    }
+    started = true;
+    pumpPromise = pumpOutputs();
+
+    startPromise = (async () => {
+      try {
+        await runtime.start();
+      } finally {
+        await stop({ reason: 'runtime-complete', cancel: false });
+      }
+    })();
+
+    return startPromise;
+  }
+
+  if (autoStart) {
+    start().catch((error) => {
+      console.error('[openagent:websocket-ui] Failed to start agent runtime:', error);
+    });
+  }
+
+  return {
+    runtime,
+    start,
+    stop,
+  };
+}
+
+export default { createWebSocketUi };

--- a/tests/unit/context.md
+++ b/tests/unit/context.md
@@ -16,6 +16,7 @@
 - `openaiResponses.test.js`: validates the shared OpenAI response helper respects reasoning environment overrides.
 - `jsonAssetValidator.test.js`: guards JSON schema helpers and prompt synchronization checks.
 - `historyCompactor.test.js`: asserts old history is summarized and that the generated summary is surfaced to the human via logging.
+- `websocketUi.test.js`: exercises the WebSocket UI binding to ensure prompts/events route correctly and disconnections cancel the runtime.
 
 ## Positive Signals
 

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -377,3 +377,10 @@ describe('loadPreapprovedConfig', () => {
     }
   });
 });
+
+describe('createWebSocketUi export', () => {
+  test('exposes the WebSocket binding helper', async () => {
+    const { mod } = await loadModule();
+    expect(typeof mod.createWebSocketUi).toBe('function');
+  });
+});

--- a/tests/unit/websocketUi.test.js
+++ b/tests/unit/websocketUi.test.js
@@ -1,0 +1,158 @@
+import { jest } from '@jest/globals';
+
+import { createWebSocketUi } from '../../src/ui/websocket.js';
+import { createAsyncQueue } from '../../src/utils/asyncQueue.js';
+
+function createMockSocket() {
+  const listeners = new Map();
+  const api = {
+    send: jest.fn(),
+    on(event, handler) {
+      const existing = listeners.get(event) ?? new Set();
+      existing.add(handler);
+      listeners.set(event, existing);
+      return api;
+    },
+    off(event, handler) {
+      const existing = listeners.get(event);
+      if (!existing) return api;
+      existing.delete(handler);
+      if (existing.size === 0) {
+        listeners.delete(event);
+      }
+      return api;
+    },
+    emit(event, ...args) {
+      const callbacks = listeners.get(event);
+      if (!callbacks) return;
+      for (const cb of [...callbacks]) {
+        cb(...args);
+      }
+    },
+  };
+  return api;
+}
+
+function createMockRuntime() {
+  const outputs = createAsyncQueue();
+  let resolveStart;
+  const startPromise = new Promise((resolve) => {
+    resolveStart = resolve;
+  });
+  return {
+    runtime: {
+      outputs,
+      start: jest.fn(() => startPromise),
+      submitPrompt: jest.fn(),
+      cancel: jest.fn(),
+    },
+    outputs,
+    resolveStart,
+  };
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('createWebSocketUi', () => {
+  test('forwards prompts and outbound events', async () => {
+    const socket = createMockSocket();
+    const { runtime, outputs, resolveStart } = createMockRuntime();
+
+    const ui = createWebSocketUi({
+      socket,
+      createRuntime: () => runtime,
+      autoStart: false,
+    });
+
+    const startPromise = ui.start();
+    await flush();
+    expect(runtime.start).toHaveBeenCalledTimes(1);
+
+    socket.emit('message', JSON.stringify({ type: 'prompt', prompt: 'hello' }));
+    socket.emit('message', 'plain text prompt');
+
+    expect(runtime.submitPrompt).toHaveBeenCalledWith('hello');
+    expect(runtime.submitPrompt).toHaveBeenCalledWith('plain text prompt');
+
+    socket.emit('message', JSON.stringify({ type: 'cancel', payload: { foo: 'bar' } }));
+    expect(runtime.cancel).toHaveBeenCalledWith({ foo: 'bar' });
+
+    outputs.push({ type: 'status', message: 'ready' });
+    await flush();
+
+    expect(socket.send).toHaveBeenCalled();
+    const payload = socket.send.mock.calls[socket.send.mock.calls.length - 1][0];
+    expect(JSON.parse(payload)).toEqual({ type: 'status', message: 'ready' });
+
+    resolveStart();
+    await ui.stop({ cancel: false });
+    await startPromise;
+  });
+
+  test('cancels runtime when socket closes', async () => {
+    const socket = createMockSocket();
+    const { runtime, resolveStart } = createMockRuntime();
+
+    const ui = createWebSocketUi({
+      socket,
+      createRuntime: () => runtime,
+      autoStart: false,
+    });
+
+    const startPromise = ui.start();
+    await flush();
+
+    socket.emit('close');
+    await flush();
+
+    expect(runtime.cancel).toHaveBeenCalledWith({ reason: 'socket-close' });
+
+    resolveStart();
+    await startPromise;
+  });
+
+  test('emits error event when parse fails', async () => {
+    const socket = createMockSocket();
+    const { runtime, resolveStart } = createMockRuntime();
+
+    const ui = createWebSocketUi({
+      socket,
+      createRuntime: () => runtime,
+      autoStart: false,
+      parseIncoming: () => {
+        throw new Error('boom');
+      },
+    });
+
+    const startPromise = ui.start();
+    await flush();
+
+    socket.emit('message', 'ignored');
+    await flush();
+
+    expect(socket.send).toHaveBeenCalled();
+    const payload = socket.send.mock.calls[0][0];
+    expect(JSON.parse(payload).type).toBe('error');
+
+    resolveStart();
+    await ui.stop({ cancel: false });
+    await startPromise;
+  });
+
+  test('autoStart immediately begins runtime', async () => {
+    const socket = createMockSocket();
+    const { runtime, resolveStart } = createMockRuntime();
+
+    createWebSocketUi({
+      socket,
+      createRuntime: () => runtime,
+      autoStart: true,
+    });
+
+    await flush();
+
+    expect(runtime.start).toHaveBeenCalledTimes(1);
+
+    resolveStart();
+  });
+});


### PR DESCRIPTION
## Summary
- add a framework-agnostic WebSocket UI binding that wires socket messages into the agent runtime and streams outgoing events
- document the new ui/ directory and expose the binding from the public library surface
- cover the WebSocket helper with focused unit tests and ensure the root export continues to surface it

## Testing
- npm test -- websocketUi.test.js
- npm test -- index.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3d07e5c0083288625e1b3d9ac71ab