### PR TITLE
build: automate npm publishing via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish package to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to publish (e.g. v2.1.0)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Run quality gates and publish
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: '20'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "TAG_NAME=${{ inputs.tag }}" >> "$GITHUB_ENV"
+          else
+            echo "TAG_NAME=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Verify release tag matches package version
+        run: npm run release:verify-tag -- "$TAG_NAME"
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN secret is missing; cannot publish." >&2
+            exit 1
+          fi
+          npm publish --provenance --access public

--- a/docs/context.md
+++ b/docs/context.md
@@ -10,6 +10,7 @@
 - `modernization-plan.md`: staged roadmap covering lint/format adoption, ESM migration, service extraction, observability.
 - `openai-cancellation.md`: research note confirming AbortSignal support in `openai@6.x` and fallback strategies.
 - `js-dependency-graph.md`: Mermaid diagram mapping relative imports among ESM modules.
+- `publishing.md`: documents the GitHub Actions-powered npm release pipeline plus the manual fallback procedure.
 
 ## Positive Signals
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,52 @@
+# Publishing OpenAgent to npm
+
+This guide explains how the automated GitHub Actions workflow ships the `openagent` package to npm and how to fall back to a manual publish if needed.
+
+## 1. Automated release pipeline
+
+We publish via `.github/workflows/publish.yml`. The workflow can be triggered in two ways:
+
+1. **Release event** – create a GitHub Release whose tag matches the package version (for example, `v2.1.0`). Once the release is published the workflow runs automatically.
+2. **Manual dispatch** – run the workflow from the *Actions* tab and provide the tag (e.g. `v2.1.0`). Useful for dry runs or re-publishing a failed release after fixing infrastructure issues.
+
+### Required secrets and permissions
+
+- Create an npm automation token with publish rights and add it as the `NPM_TOKEN` repository secret.
+- The workflow uses Node.js 20 and expects `npm ci`, `npm run lint`, and `npm test` to succeed before publishing.
+- GitHub provenance is enabled (`npm publish --provenance`) so the repository must have GitHub Actions provenance configured (it is on by default for public repos).
+
+### Release preparation checklist
+
+Before triggering the workflow:
+
+1. **Bump the package version** locally using `npm version <patch|minor|major>`. Commit and push the change (including the git tag that `npm version` creates).
+2. **Update changelog and docs** with user-facing changes.
+3. **Verify CI is green** on the branch you plan to tag.
+
+The publish workflow enforces an extra guardrail by running `npm run release:verify-tag -- <tag>`. This script compares the git tag with `package.json` to prevent accidental mismatches.
+
+### What the workflow does
+
+1. Checks out the repository with full history so tags are available.
+2. Installs dependencies via `npm ci`.
+3. Runs linting (`npm run lint`) and tests (`npm test`).
+4. Confirms the triggering tag matches the version in `package.json`.
+5. Publishes to npm using the `NPM_TOKEN` secret.
+
+If any step fails the publish halts, keeping the release from reaching npm.
+
+## 2. Manual publish (fallback)
+
+If GitHub Actions is unavailable, you can still publish manually:
+
+1. Run the quality gates locally:
+   ```sh
+   npm run lint
+   npm test
+   ```
+2. Bump the version and push the commit and tag created by `npm version`.
+3. Authenticate (`npm login`) with an account that has publish rights.
+4. Publish using `npm publish --access public`.
+5. Verify the new version on <https://www.npmjs.com/package/openagent> and update any release notes.
+
+Manual publishes should be rare—prefer the automated pipeline so every release is reproducible and validated.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "release:verify-tag": "node ./scripts/verify-release-tag.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/verify-release-tag.js
+++ b/scripts/verify-release-tag.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Simple guardrail for the release workflow:
+ * - Accepts the git tag that triggered the workflow as the first CLI argument.
+ * - Compares the tag (with or without a leading "v") to the version defined in package.json.
+ * - Exits with a non-zero status if they do not match so the publish step halts early.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const [, , rawTag] = process.argv;
+
+if (!rawTag) {
+  console.error('Usage: node ./scripts/verify-release-tag.js <tag>');
+  process.exit(1);
+}
+
+// Normalise the tag so we can accept both `v2.0.0` and `2.0.0` formats.
+const tagWithoutPrefix = rawTag.startsWith('v') ? rawTag.slice(1) : rawTag;
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const packageJsonPath = path.join(currentDir, '..', 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const packageVersion = packageJson.version;
+
+if (!packageVersion) {
+  console.error('package.json is missing a version field; aborting publish.');
+  process.exit(1);
+}
+
+if (packageVersion !== tagWithoutPrefix) {
+  console.error(`Tag mismatch: package.json is ${packageVersion}, but the workflow received ${rawTag}.`);
+  process.exit(1);
+}
+
+console.log(`Validated: git tag ${rawTag} matches package version ${packageVersion}.`);


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that lint/tests before publishing to npm and requires an NPM_TOKEN secret
- add a reusable release tag verification script plus npm script so the workflow halts on mismatched tags
- refresh the publishing guide and docs index to describe the automated pipeline and manual fallback

## Testing
- npm run lint *(fails: existing Prettier violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d70f51ac832891a06650e67e4391