### PR TITLE
Promote approval and runtime helpers to dedicated classes

### DIFF
--- a/docs/class-interface-refactor-ideas.md
+++ b/docs/class-interface-refactor-ideas.md
@@ -1,0 +1,21 @@
+# Class and interface refactoring opportunities
+
+The runtime is already leaning on classes such as `ApprovalManager` and `HistoryCompactor`. This note tracks remaining and recently completed refactor candidates so future maintainers can see which helpers were promoted to explicit classes or still need attention.
+
+## Async queue -> `AsyncQueue` class ✅
+- **Status:** Implemented — `src/utils/asyncQueue.js` now exports an `AsyncQueue` class while keeping `createAsyncQueue()` as a thin compatibility wrapper.
+- **Original rationale:** Replace the factory with a small `AsyncQueue` class that hides the sentinel symbol and exposes `push`, `close`, `next`, and `[Symbol.asyncIterator]`.
+
+## Prompt coordination -> `PromptCoordinator` class ✅
+- **Status:** Implemented — `createPromptCoordinator` was replaced with a dedicated `PromptCoordinator` class in `src/agent/promptCoordinator.js` that the runtime instantiates.
+- **Original rationale:** Extract the nested helper into a class that receives `emitEvent` and `escController` dependencies in the constructor so alternative UIs can implement the same contract.
+
+## CLI thinking indicator -> `ThinkingIndicator` class
+- **Current shape:** `thinking.js` keeps module-level `intervalHandle` and `animationStart` state and exposes global `startThinking`/`stopThinking`. That makes concurrent indicators impossible and forces implicit singletons during tests.
+- **Suggested change:** Wrap the animation in a class with explicit `start`/`stop` methods and an interface (`ThinkingIndicator`) that the CLI runtime can depend on. The module can export a default singleton for backwards compatibility while letting tests instantiate isolated indicators.
+- **Why it helps:** Encapsulating the timer logic clarifies ownership of resources like intervals and stdout writes. It also lets alternative front-ends swap a no-op implementation that satisfies the interface without reaching into module globals. 
+- **Effort:** Low-to-moderate — most call sites are already using method-like functions.
+
+## Command preapproval -> `CommandApprovalService` ✅
+- **Status:** Implemented — `src/commands/preapproval.js` now centres on the `CommandApprovalService` class with a default singleton export for the CLI.
+- **Original rationale:** Move the module-level session state into an injectable service that offers `isPreapprovedCommand`, `approveForSession`, and friends.

--- a/docs/context.md
+++ b/docs/context.md
@@ -11,6 +11,8 @@
 - `openai-cancellation.md`: research note confirming AbortSignal support in `openai@6.x` and fallback strategies.
 - `js-dependency-graph.md`: Mermaid diagram mapping relative imports among ESM modules.
 - `publishing.md`: documents the GitHub Actions-powered npm release pipeline plus the manual fallback procedure.
+- `class-interface-refactor-ideas.md`: outlines stateful modules that could graduate into classes/interfaces for clearer
+  encapsulation.
 
 ## Positive Signals
 

--- a/src/agent/context.md
+++ b/src/agent/context.md
@@ -7,6 +7,7 @@
 ## Key Modules
 
 - `loop.js`: exposes the event-driven runtime (`createAgentRuntime`) that emits structured JSON events and wraps it with the legacy `createAgentLoop` helper for compatibility.
+- `promptCoordinator.js`: provides the `PromptCoordinator` class that mediates prompt requests/responses between the runtime and UI surfaces.
 - `handshake.js`: encapsulates the temporary history injection used for the initial system handshake.
   - Ensures a system prompt entry is present in history before the first model call, injecting it when consumers provide a prompt-less history.
 - `escState.js`: centralises cancellation state, allowing UI-triggered events to notify in-flight operations.

--- a/src/agent/promptCoordinator.js
+++ b/src/agent/promptCoordinator.js
@@ -1,0 +1,89 @@
+/**
+ * Coordinates prompt requests coming from the agent runtime with responses
+ * arriving from the UI layer. The previous implementation lived as an ad-hoc
+ * closure inside `loop.js`; the class form makes the buffering behaviour easier
+ * to exercise in isolation.
+ */
+export class PromptCoordinator {
+  /**
+   * @param {Object} options
+   * @param {(event: Object) => void} options.emitEvent
+   * @param {{ trigger?: Function }} [options.escState]
+   * @param {(payload?: any) => void} [options.cancelFn]
+   */
+  constructor({ emitEvent, escState, cancelFn } = {}) {
+    this.emitEvent = typeof emitEvent === 'function' ? emitEvent : () => {};
+    this.escState = escState || null;
+    this.cancelFn = typeof cancelFn === 'function' ? cancelFn : null;
+
+    /** @type {string[]} */
+    this.buffered = [];
+    /** @type {Function[]} */
+    this.waiters = [];
+  }
+
+  /**
+   * Internal helper mirroring the old closure to resolve the next waiter.
+   * @param {string} value
+   * @returns {boolean}
+   */
+  resolveNext(value) {
+    if (this.waiters.length > 0) {
+      const resolve = this.waiters.shift();
+      resolve(value);
+      return true;
+    }
+    this.buffered.push(value);
+    return false;
+  }
+
+  /**
+   * Emit a prompt request to the UI and wait for a response.
+   * @param {string} prompt
+   * @param {Object} [metadata]
+   * @returns {Promise<string>}
+   */
+  request(prompt, metadata = {}) {
+    this.emitEvent({ type: 'request-input', prompt, metadata });
+
+    if (this.buffered.length > 0) {
+      return Promise.resolve(this.buffered.shift());
+    }
+
+    return new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  /**
+   * Accept a prompt value from the UI, resolving a pending request if present.
+   * @param {string} value
+   */
+  handlePrompt(value) {
+    this.resolveNext(typeof value === 'string' ? value : '');
+  }
+
+  /**
+   * Cancel pending work when the UI asks for a stop.
+   * @param {any} payload
+   */
+  handleCancel(payload = null) {
+    if (this.cancelFn) {
+      this.cancelFn('ui-cancel');
+    }
+    this.escState?.trigger?.(payload ?? { reason: 'ui-cancel' });
+    this.emitEvent({ type: 'status', level: 'warn', message: 'Cancellation requested by UI.' });
+  }
+
+  /**
+   * Resolve all pending waiters to release consumers.
+   */
+  close() {
+    while (this.waiters.length > 0) {
+      const resolve = this.waiters.shift();
+      resolve('');
+    }
+  }
+}
+
+export default PromptCoordinator;

--- a/src/commands/preapproval.js
+++ b/src/commands/preapproval.js
@@ -1,14 +1,7 @@
 /**
- * Implements the allowlist validation and in-memory approvals for command execution.
- *
- * Responsibilities:
- * - Parse the approved command configuration from disk.
- * - Determine whether a proposed command is auto-approved.
- * - Track per-session approvals granted via the CLI prompt.
- *
- * Consumers:
- * - `src/agent/loop.js` checks proposals against the allowlist and session approvals.
- * - Unit tests exercise the individual helpers via root re-exports.
+ * Implements command approval helpers, now grouped behind a dedicated
+ * `CommandApprovalService` class. The static helpers remain exported for
+ * backwards compatibility with callers that still import individual functions.
  */
 
 import * as fs from 'node:fs';
@@ -17,208 +10,303 @@ import chalk from 'chalk';
 
 import { shellSplit } from '../utils/text.js';
 
-export function isCommandStringSafe(rawCommand) {
-  if (typeof rawCommand !== 'string') {
-    return false;
+export class CommandApprovalService {
+  /**
+   * @param {Object} [options]
+   * @param {Object} [options.config]
+   * @param {Set<string>} [options.sessionApprovals]
+   */
+  constructor({ config, sessionApprovals } = {}) {
+    this.allowlistConfig = config ?? CommandApprovalService.loadPreapprovedConfig();
+    this.sessionApprovals = sessionApprovals ?? new Set();
   }
 
-  const runRaw = rawCommand.trim();
-  if (!runRaw) {
-    return false;
+  /**
+   * Return the allowlist configuration associated with the instance.
+   * @returns {Object}
+   */
+  get config() {
+    return this.allowlistConfig;
   }
 
-  if (/\r|\n/.test(runRaw)) {
-    return false;
+  /**
+   * Replace the stored allowlist configuration.
+   * Useful for tests that want to inject fixtures without mutating globals.
+   * @param {Object} cfg
+   */
+  set config(cfg) {
+    this.allowlistConfig = cfg || { allowlist: [] };
   }
 
-  const forbidden = [
-    /;|&&|\|\|/, // chaining commands or logical operators
-    /\|/, // piping output into another process
-    /`/, // legacy command substitution
-    /\$\(/, // modern command substitution
-    /<\s*\(/, // process substitution with optional whitespace
-    />\s*\(/, // output process substitution
-    /(^|[^&])&([^&]|$)/, // background execution with single ampersand
-    /<<</, // here-strings
-    /<</, // here-documents
-    /&>/, // redirecting all output to a file
-  ];
-
-  if (forbidden.some((re) => re.test(runRaw))) {
-    return false;
+  /**
+   * Determine whether the provided command is automatically approved.
+   * @param {Object} command
+   * @param {Object} [cfg]
+   * @returns {boolean}
+   */
+  isPreapprovedCommand(command, cfg = this.config) {
+    return CommandApprovalService.isPreapprovedCommand(command, cfg);
   }
 
-  if (/^\s*sudo\b/.test(runRaw)) {
-    return false;
-  }
-
-  if (/(^|\s)[0-9]*>>?\s/.test(runRaw)) {
-    return false;
-  }
-
-  if (/\d?>&\d?/.test(runRaw)) {
-    return false;
-  }
-
-  return true;
-}
-
-export function loadPreapprovedConfig() {
-  const cfgPath = path.join(process.cwd(), 'approved_commands.json');
-  try {
-    if (fs.existsSync(cfgPath)) {
-      const raw = fs.readFileSync(cfgPath, 'utf8');
-      const parsed = JSON.parse(raw);
-      return parsed && parsed.allowlist ? parsed : { allowlist: [] };
+  /**
+   * Whether the command has already been approved during this session.
+   * @param {Object} command
+   * @returns {boolean}
+   */
+  isSessionApproved(command) {
+    try {
+      return this.sessionApprovals.has(CommandApprovalService.commandSignature(command));
+    } catch (err) {
+      return false;
     }
-  } catch (err) {
-    console.error(chalk.yellow('Warning: Failed to load approved_commands.json:'), err.message);
   }
-  return { allowlist: [] };
-}
 
-export function isPreapprovedCommand(command, cfg) {
-  try {
-    const runRaw = (command && command.run ? String(command.run) : '').trim();
-    if (!runRaw) return false;
+  /**
+   * Record the command signature for session-long approvals.
+   * @param {Object} command
+   */
+  approveForSession(command) {
+    try {
+      this.sessionApprovals.add(CommandApprovalService.commandSignature(command));
+    } catch (err) {
+      // ignore
+    }
+  }
 
-    if (runRaw.toLowerCase().startsWith('browse ')) {
-      const url = runRaw.slice(7).trim();
-      if (!url || /\s/.test(url)) return false;
-      try {
-        const u = new URL(url);
-        if (u.protocol === 'http:' || u.protocol === 'https:') return true;
-      } catch (err) {
-        return false;
+  /**
+   * Reset all stored session approvals.
+   */
+  resetSessionApprovals() {
+    this.sessionApprovals.clear();
+  }
+
+  /**
+   * Load the allowlist configuration from disk.
+   * @returns {{ allowlist: Array }}
+   */
+  static loadPreapprovedConfig() {
+    const cfgPath = path.join(process.cwd(), 'approved_commands.json');
+    try {
+      if (fs.existsSync(cfgPath)) {
+        const raw = fs.readFileSync(cfgPath, 'utf8');
+        const parsed = JSON.parse(raw);
+        return parsed && parsed.allowlist ? parsed : { allowlist: [] };
       }
+    } catch (err) {
+      console.error(chalk.yellow('Warning: Failed to load approved_commands.json:'), err.message);
+    }
+    return { allowlist: [] };
+  }
+
+  /**
+   * Lightweight validation to prevent obviously unsafe shell invocations.
+   * @param {string} rawCommand
+   * @returns {boolean}
+   */
+  static isCommandStringSafe(rawCommand) {
+    if (typeof rawCommand !== 'string') {
       return false;
     }
 
-    if (!isCommandStringSafe(runRaw)) return false;
-
-    const shellOpt = command && 'shell' in command ? command.shell : undefined;
-    if (typeof shellOpt === 'string') {
-      const normalized = String(shellOpt).trim().toLowerCase();
-      if (!['bash', 'sh'].includes(normalized)) return false;
+    const runRaw = rawCommand.trim();
+    if (!runRaw) {
+      return false;
     }
 
-    const tokens = shellSplit(runRaw);
-    if (!tokens.length) return false;
-    const base = path.basename(tokens[0]);
-
-    const list = cfg && Array.isArray(cfg.allowlist) ? cfg.allowlist : [];
-    const entry = list.find((item) => item && item.name === base);
-    if (!entry) return false;
-
-    let sub = '';
-    for (let i = 1; i < tokens.length; i++) {
-      const token = tokens[i];
-      if (!token.startsWith('-')) {
-        sub = token;
-        break;
-      }
+    if (/\r|\n/.test(runRaw)) {
+      return false;
     }
 
-    if (Array.isArray(entry.subcommands) && entry.subcommands.length > 0) {
-      if (!entry.subcommands.includes(sub)) return false;
-      if (['python', 'python3', 'pip', 'node', 'npm'].includes(base)) {
-        const afterIdx = tokens.indexOf(sub);
-        if (afterIdx !== -1 && tokens.length > afterIdx + 1) return false;
-      }
+    const forbidden = [
+      /;|&&|\|\|/, // chaining commands or logical operators
+      /\|/, // piping output into another process
+      /`/, // legacy command substitution
+      /\$\(/, // modern command substitution
+      /<\s*\(/, // process substitution with optional whitespace
+      />\s*\(/, // output process substitution
+      /(^|[^&])&([^&]|$)/, // background execution with single ampersand
+      /<<</, // here-strings
+      /<</, // here-documents
+      /&>/, // redirecting all output to a file
+    ];
+
+    if (forbidden.some((re) => re.test(runRaw))) {
+      return false;
     }
 
-    const joined = ' ' + tokens.slice(1).join(' ') + ' ';
-    switch (base) {
-      case 'sed':
-        if (/(^|\s)-i(\b|\s)/.test(joined)) return false;
-        break;
-      case 'find':
-        if (/\s-exec\b/.test(joined) || /\s-delete\b/.test(joined)) return false;
-        break;
-      case 'curl': {
-        if (/(^|\s)-X\s*(POST|PUT|PATCH|DELETE)\b/i.test(joined)) return false;
-        if (
-          /(^|\s)(--data(-binary|-raw|-urlencode)?|-d|--form|-F|--upload-file|-T)\b/i.test(joined)
-        )
-          return false;
-        if (/(^|\s)(-O|--remote-name|--remote-header-name)\b/.test(joined)) return false;
-        const tokensAfterBase = tokens.slice(1);
-        for (let i = 0; i < tokensAfterBase.length; i++) {
-          const token = tokensAfterBase[i];
-          if (token === '-o' || token === '--output') {
-            const name = tokensAfterBase[i + 1] || '';
-            if (name !== '-') return false;
-          }
-          if (token.startsWith('-o') && token.length > 2) return false;
-        }
-        break;
-      }
-      case 'wget': {
-        if (/\s--spider\b/.test(joined)) {
-          // allowed
-        } else {
-          const tokensAfterBase = tokens.slice(1);
-          for (let i = 0; i < tokensAfterBase.length; i++) {
-            const token = tokensAfterBase[i];
-            if (token === '-O' || token === '--output-document') {
-              const name = tokensAfterBase[i + 1] || '';
-              if (name !== '-') return false;
-            }
-            if (token.startsWith('-O') && token !== '-O') return false;
-          }
-        }
-        break;
-      }
-      case 'ping': {
-        const idx = tokens.indexOf('-c');
-        if (idx === -1) return false;
-        const count = parseInt(tokens[idx + 1], 10);
-        if (!Number.isFinite(count) || count > 3 || count < 1) return false;
-        break;
-      }
-      default:
-        break;
+    if (/^\s*sudo\b/.test(runRaw)) {
+      return false;
+    }
+
+    if (/(^|\s)[0-9]*>>?\s/.test(runRaw)) {
+      return false;
+    }
+
+    if (/\d?>&\d?/.test(runRaw)) {
+      return false;
     }
 
     return true;
-  } catch (err) {
-    return false;
+  }
+
+  /**
+   * Compute a stable signature for storing approvals.
+   * @param {Object} cmd
+   * @returns {string}
+   */
+  static commandSignature(cmd) {
+    return JSON.stringify({
+      shell: cmd?.shell || 'bash',
+      run: typeof cmd?.run === 'string' ? cmd.run : '',
+      cwd: cmd?.cwd || '.',
+    });
+  }
+
+  /**
+   * Core allowlist evaluation shared by the instance and the static export.
+   * @param {Object} command
+   * @param {Object} cfg
+   * @returns {boolean}
+   */
+  static isPreapprovedCommand(command, cfg) {
+    try {
+      const runRaw = (command && command.run ? String(command.run) : '').trim();
+      if (!runRaw) return false;
+
+      if (runRaw.toLowerCase().startsWith('browse ')) {
+        const url = runRaw.slice(7).trim();
+        if (!url || /\s/.test(url)) return false;
+        try {
+          const u = new URL(url);
+          if (u.protocol === 'http:' || u.protocol === 'https:') return true;
+        } catch (err) {
+          return false;
+        }
+        return false;
+      }
+
+      if (!CommandApprovalService.isCommandStringSafe(runRaw)) return false;
+
+      const shellOpt = command && 'shell' in command ? command.shell : undefined;
+      if (typeof shellOpt === 'string') {
+        const normalized = String(shellOpt).trim().toLowerCase();
+        if (!['bash', 'sh'].includes(normalized)) return false;
+      }
+
+      const tokens = shellSplit(runRaw);
+      if (!tokens.length) return false;
+      const base = path.basename(tokens[0]);
+
+      const list = cfg && Array.isArray(cfg.allowlist) ? cfg.allowlist : [];
+      const entry = list.find((item) => item && item.name === base);
+      if (!entry) return false;
+
+      let sub = '';
+      for (let i = 1; i < tokens.length; i++) {
+        const token = tokens[i];
+        if (!token.startsWith('-')) {
+          sub = token;
+          break;
+        }
+      }
+
+      if (Array.isArray(entry.subcommands) && entry.subcommands.length > 0) {
+        if (!entry.subcommands.includes(sub)) return false;
+        if (['python', 'python3', 'pip', 'node', 'npm'].includes(base)) {
+          const afterIdx = tokens.indexOf(sub);
+          if (afterIdx !== -1 && tokens.length > afterIdx + 1) return false;
+        }
+      }
+
+      const joined = ' ' + tokens.slice(1).join(' ') + ' ';
+      switch (base) {
+        case 'sed':
+          if (/(^|\s)-i(\b|\s)/.test(joined)) return false;
+          break;
+        case 'find':
+          if (/\s-exec\b/.test(joined) || /\s-delete\b/.test(joined)) return false;
+          break;
+        case 'curl': {
+          if (/(^|\s)-X\s*(POST|PUT|PATCH|DELETE)\b/i.test(joined)) return false;
+          if (
+            /(^|\s)(--data(-binary|-raw|-urlencode)?|-d|--form|-F|--upload-file|-T)\b/i.test(joined)
+          )
+            return false;
+          if (/(^|\s)(-O|--remote-name|--remote-header-name)\b/.test(joined)) return false;
+          const tokensAfterBase = tokens.slice(1);
+          for (let i = 0; i < tokensAfterBase.length; i++) {
+            const token = tokensAfterBase[i];
+            if (token === '-o' || token === '--output') {
+              const name = tokensAfterBase[i + 1] || '';
+              if (name !== '-') return false;
+            }
+            if (token.startsWith('-o') && token.length > 2) return false;
+          }
+          break;
+        }
+        case 'wget': {
+          if (/\s--spider\b/.test(joined)) {
+            // allowed
+          } else {
+            const tokensAfterBase = tokens.slice(1);
+            for (let i = 0; i < tokensAfterBase.length; i++) {
+              const token = tokensAfterBase[i];
+              if (token === '-O' || token === '--output-document') {
+                const name = tokensAfterBase[i + 1] || '';
+                if (name !== '-') return false;
+              }
+              if (token.startsWith('-O') && token !== '-O') return false;
+            }
+          }
+          break;
+        }
+        case 'ping': {
+          const idx = tokens.indexOf('-c');
+          if (idx === -1) return false;
+          const count = parseInt(tokens[idx + 1], 10);
+          if (!Number.isFinite(count) || count > 3 || count < 1) return false;
+          break;
+        }
+        default:
+          break;
+      }
+
+      return true;
+    } catch (err) {
+      return false;
+    }
   }
 }
 
-const sessionApprovals = new Set();
+const defaultCommandApprovalService = new CommandApprovalService();
 
-export function commandSignature(cmd) {
-  return JSON.stringify({
-    shell: cmd.shell || 'bash',
-    run: typeof cmd.run === 'string' ? cmd.run : '',
-    cwd: cmd.cwd || '.',
-  });
+export const loadPreapprovedConfig = CommandApprovalService.loadPreapprovedConfig;
+export const isCommandStringSafe = CommandApprovalService.isCommandStringSafe;
+export const commandSignature = CommandApprovalService.commandSignature;
+
+export function isPreapprovedCommand(command, cfg = defaultCommandApprovalService.config) {
+  return CommandApprovalService.isPreapprovedCommand(command, cfg);
 }
 
 export function isSessionApproved(cmd) {
-  try {
-    return sessionApprovals.has(commandSignature(cmd));
-  } catch (err) {
-    return false;
-  }
+  return defaultCommandApprovalService.isSessionApproved(cmd);
 }
 
 export function approveForSession(cmd) {
-  try {
-    sessionApprovals.add(commandSignature(cmd));
-  } catch (err) {
-    // ignore
-  }
+  return defaultCommandApprovalService.approveForSession(cmd);
 }
 
 export function resetSessionApprovals() {
-  sessionApprovals.clear();
+  defaultCommandApprovalService.resetSessionApprovals();
 }
 
-export const PREAPPROVED_CFG = loadPreapprovedConfig();
+export const PREAPPROVED_CFG = defaultCommandApprovalService.config;
+
+export const sessionApprovalService = defaultCommandApprovalService;
 
 export default {
+  CommandApprovalService,
+  sessionApprovalService,
   loadPreapprovedConfig,
   isPreapprovedCommand,
   isSessionApproved,

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -32,6 +32,8 @@ import {
   runUnescapeString,
 } from '../commands/run.js';
 import {
+  CommandApprovalService,
+  sessionApprovalService,
   loadPreapprovedConfig,
   isPreapprovedCommand,
   isSessionApproved,
@@ -81,6 +83,8 @@ export {
   runReplace,
   runEscapeString,
   runUnescapeString,
+  CommandApprovalService,
+  sessionApprovalService,
   loadPreapprovedConfig,
   isPreapprovedCommand,
   isSessionApproved,
@@ -131,6 +135,8 @@ const exported = {
   runReplace,
   runEscapeString,
   runUnescapeString,
+  CommandApprovalService,
+  sessionApprovalService,
   loadPreapprovedConfig,
   isPreapprovedCommand,
   isSessionApproved,

--- a/src/utils/context.md
+++ b/src/utils/context.md
@@ -6,6 +6,7 @@
 
 ## Modules
 
+- `asyncQueue.js`: exposes the `AsyncQueue` class (with a compatibility factory) used to shuttle events between the agent loop and UIs.
 - `cancellation.js`: stack-based cancellation manager enabling ESC-triggered aborts and nested operations.
 - `output.js`: merges stdout/stderr and provides preview builders used when rendering command results.
 - `plan.js`: supplies plan inspection helpers (e.g., `planHasOpenSteps`).

--- a/tests/unit/websocketUi.test.js
+++ b/tests/unit/websocketUi.test.js
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 
 import { createWebSocketUi } from '../../src/ui/websocket.js';
-import { createAsyncQueue } from '../../src/utils/asyncQueue.js';
+import { AsyncQueue } from '../../src/utils/asyncQueue.js';
 
 function createMockSocket() {
   const listeners = new Map();
@@ -34,7 +34,7 @@ function createMockSocket() {
 }
 
 function createMockRuntime() {
-  const outputs = createAsyncQueue();
+  const outputs = new AsyncQueue();
   let resolveStart;
   const startPromise = new Promise((resolve) => {
     resolveStart = resolve;


### PR DESCRIPTION
## Summary
- replace the async queue factory with an `AsyncQueue` class and update runtime/test usage
- extract a `PromptCoordinator` class to manage UI prompt buffering and cancellation wiring
- encapsulate command approval helpers in `CommandApprovalService` and refresh docs/context for the new abstractions

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e3dcd15e6c832880421520d98d6ab9