### PR TITLE
Fix npm publish provenance permissions

### DIFF
--- a/.github/workflows/context.md
+++ b/.github/workflows/context.md
@@ -7,7 +7,7 @@ Automation pipelines for CI, releases, and quality checks.
 ## Key Workflows
 
 - `test.yml`: runs linting and tests on pull requests.
-- `publish.yml`: publishes the package to npm whenever a GitHub release is published or manually triggered.
+- `publish.yml`: publishes the package to npm whenever a GitHub release is published or manually triggered. Requires `id-token: write` so the `npm publish --provenance` step can request an OIDC token.
 - `auto-release.yml`: on every push to `main` (i.e., post-merge), automatically bumps the minor version, tags the release, and creates a GitHub release so that `publish.yml` can push the new version to npm.
 
 ## Notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -12,6 +12,7 @@ We publish via `.github/workflows/publish.yml`. The workflow can be triggered in
 ### Required secrets and permissions
 
 - Create an npm automation token with publish rights and add it as the `NPM_TOKEN` repository secret.
+- Grant the workflow OIDC permissions by keeping `id-token: write` enabled so `npm publish --provenance` can mint a provenance attestation.
 - The workflow uses Node.js 20 and expects `npm ci`, `npm run lint`, and `npm test` to succeed before publishing.
 - GitHub provenance is enabled (`npm publish --provenance`) so the repository must have GitHub Actions provenance configured (it is on by default for public repos).
 


### PR DESCRIPTION
## Summary
- grant the publish workflow `id-token: write` so npm provenance can be issued during automation
- document the OIDC requirement in the publishing guide and workflow context

## Testing
- no tests were run (workflow/documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3ec5d31888328ac3df6c965b2bcc2