### PR TITLE
build: scope package for npm publishing

### DIFF
--- a/.github/workflows/context.md
+++ b/.github/workflows/context.md
@@ -7,7 +7,7 @@ Automation pipelines for CI, releases, and quality checks.
 ## Key Workflows
 
 - `test.yml`: runs linting and tests on pull requests.
-- `publish.yml`: publishes the package to npm whenever a GitHub release is published or manually triggered. Requires `id-token: write` so the `npm publish --provenance` step can request an OIDC token.
+- `publish.yml`: publishes `@asynkron/openagent` to npm whenever a GitHub release is published or manually triggered. Requires `id-token: write` so the `npm publish --provenance` step can request an OIDC token and now skips publication if the version already exists on npm.
 - `auto-release.yml`: on every push to `main` (i.e., post-merge), automatically bumps the minor version, tags the release, and creates a GitHub release so that `publish.yml` can push the new version to npm.
 
 ## Notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
+          scope: '@asynkron'
+          always-auth: true
 
       - name: Install dependencies
         run: npm ci
@@ -51,7 +53,20 @@ jobs:
       - name: Verify release tag matches package version
         run: npm run release:verify-tag -- "$TAG_NAME"
 
+      - name: Check if npm version already exists
+        id: version_check
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+          if npm view "@asynkron/openagent@$PACKAGE_VERSION" version > /dev/null 2>&1; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $PACKAGE_VERSION already exists on npm; skipping publish."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
+        if: steps.version_check.outputs.already_published != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |

--- a/docs/context.md
+++ b/docs/context.md
@@ -10,7 +10,8 @@
 - `modernization-plan.md`: staged roadmap covering lint/format adoption, ESM migration, service extraction, observability.
 - `openai-cancellation.md`: research note confirming AbortSignal support in `openai@6.x` and fallback strategies.
 - `js-dependency-graph.md`: Mermaid diagram mapping relative imports among ESM modules.
-- `publishing.md`: documents the GitHub Actions-powered npm release pipeline plus the manual fallback procedure.
+- `publishing.md`: documents the GitHub Actions-powered npm release pipeline, troubleshooting guidance (e.g. npm 403 errors),
+  and the manual fallback procedure.
 - `class-interface-refactor-ideas.md`: outlines stateful modules that could graduate into classes/interfaces for clearer
   encapsulation.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "openagent",
+  "name": "@asynkron/openagent",
   "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openagent",
+      "name": "@asynkron/openagent",
       "version": "2.2.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openagent",
+  "name": "@asynkron/openagent",
   "version": "2.2.0",
   "description": "Simple Node.JS based AI agent",
   "type": "module",
@@ -35,14 +35,14 @@
   "devDependencies": {
     "@eslint/js": "^9.37.0",
     "acorn": "^8.15.0",
+    "ajv": "^8.17.1",
     "eslint": "^8.57.0",
-    "eslint-plugin-import": "^2.29.1",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "^5.1.3",
     "esprima": "^4.0.1",
     "globals": "^16.4.0",
     "jest": "^29.7.0",
-    "prettier": "^3.2.5",
-    "ajv": "^8.17.1"
+    "prettier": "^3.2.5"
   }
 }

--- a/tests/unit/esmEntry.test.js
+++ b/tests/unit/esmEntry.test.js
@@ -17,10 +17,10 @@ describe('esm entry point', () => {
     expect(entry.PREAPPROVED_CFG).toBeDefined();
   });
 
-  test('package consumers can import("openagent")', () => {
+  test('package consumers can import("@asynkron/openagent")', () => {
     // Spawn a clean Node.js process so we exercise the public package entry.
     const script = `
-      import('openagent').then((mod) => {
+      import('@asynkron/openagent').then((mod) => {
         const resolved = mod.default ?? mod;
         console.log(JSON.stringify({
           hasLoop: typeof resolved.agentLoop === 'function',


### PR DESCRIPTION
## Summary
- rename the package to the @asynkron scope so the release automation can publish without colliding with the existing unscoped name
- teach the publish workflow about the scoped package, enforce always-auth, and skip npm publishes when the version already exists
- update the ESM entry test to validate the new package name and keep the workflow context docs accurate

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3eedd723483288adcdfde46468775