### PR TITLE
Fix history compactor log metrics

### DIFF
--- a/src/agent/historyCompactor.js
+++ b/src/agent/historyCompactor.js
@@ -123,9 +123,12 @@ export class HistoryCompactor {
       content: `${DEFAULT_SUMMARY_PREFIX}\n${summarizedText}`.trim(),
     };
 
+    const originalHistoryLength = history.length;
     history.splice(firstContentIndex, entriesToCompactCount, compactedEntry);
+    // Log the before/after lengths explicitly so the compaction impact is clear.
     this._log('log', '[history-compactor] Compacted history entries.', {
-      originalEntries: entriesToCompactCount,
+      entriesCompacted: entriesToCompactCount,
+      originalHistoryLength,
       resultingHistoryLength: history.length,
     });
 

--- a/tests/unit/historyCompactor.test.js
+++ b/tests/unit/historyCompactor.test.js
@@ -56,6 +56,14 @@ describe('HistoryCompactor', () => {
     expect(logger.log).toHaveBeenCalledWith(
       '[history-compactor] Compacted summary:\nCondensed summary.',
     );
+    expect(logger.log).toHaveBeenCalledWith(
+      '[history-compactor] Compacted history entries.',
+      {
+        entriesCompacted: 2,
+        originalHistoryLength: 5,
+        resultingHistoryLength: 4,
+      },
+    );
 
     const [payload, options] = responsesCreate.mock.calls[0];
     expect(payload.model).toBe('test-model');


### PR DESCRIPTION
## Summary
- capture the original history length before compaction and include it in the log metadata
- update the history compactor unit test to validate the new logging structure

## Testing
- npm test -- historyCompactor

------
https://chatgpt.com/codex/tasks/task_e_68e418c34ce08328a5d6adfcbec37c45