### PR TITLE
Add plan progress tracking to CLI

### DIFF
--- a/src/agent/context.md
+++ b/src/agent/context.md
@@ -6,7 +6,7 @@
 
 ## Key Modules
 
-- `loop.js`: exposes the event-driven runtime (`createAgentRuntime`) that emits structured JSON events and wraps it with the legacy `createAgentLoop` helper for compatibility.
+- `loop.js`: exposes the event-driven runtime (`createAgentRuntime`) that emits structured JSON events, including plan progress notifications, and wraps it with the legacy `createAgentLoop` helper for compatibility.
 - `promptCoordinator.js`: provides the `PromptCoordinator` class that mediates prompt requests/responses between the runtime and UI surfaces.
 - `escState.js`: centralises cancellation state, allowing UI-triggered events to notify in-flight operations.
 - `passExecutor.js`: performs an agent pass (OpenAI request, JSON parsing, plan updates, approvals, command execution, observation logging).

--- a/src/cli/context.md
+++ b/src/cli/context.md
@@ -8,7 +8,7 @@
 
 - `runtime.js`: wires the agent runtime to the terminal renderer and exports `agentLoop` plus command tracking helpers used by the CLI entry point.
 - `io.js`: readline wrapper with ESC detection (emits `ESCAPE_EVENT`, cancels active operations, highlights prompts).
-- `render.js`: Markdown-based renderer for plans/messages/command summaries.
+- `render.js`: Markdown-based renderer for plans/messages/command summaries and the plan progress bar.
 - `thinking.js`: spinner that displays elapsed time while awaiting API responses.
 - `status.js`: prints transient status lines such as the remaining context window before issuing model requests.
 - `runner.js`: parses CLI arguments, forwards template/shortcut subcommands, and launches the agent loop.

--- a/src/cli/render.js
+++ b/src/cli/render.js
@@ -115,6 +115,46 @@ export function renderPlan(plan) {
   display('Plan', planLines, 'cyan');
 }
 
+// Render a compact progress indicator so humans can track plan completion at a glance.
+export function renderPlanProgress(progress) {
+  if (!progress || typeof progress !== 'object') {
+    return;
+  }
+
+  const total = Number.isFinite(progress.totalSteps) ? progress.totalSteps : 0;
+  const completed = Number.isFinite(progress.completedSteps) ? progress.completedSteps : 0;
+  const ratio = Number.isFinite(progress.ratio)
+    ? progress.ratio
+    : total > 0
+      ? completed / total
+      : 0;
+
+  if (total <= 0) {
+    console.log(chalk.blueBright('Plan progress: ') + chalk.dim('no active steps yet.'));
+    return;
+  }
+
+  const normalized = Math.min(1, Math.max(0, ratio));
+  const barWidth = 20;
+  let filled = Math.round(normalized * barWidth);
+  if (normalized > 0 && filled === 0) {
+    filled = 1;
+  }
+  if (normalized >= 1) {
+    filled = barWidth;
+  }
+  const empty = Math.max(0, barWidth - filled);
+
+  const filledBar = filled > 0 ? chalk.green('█'.repeat(filled)) : '';
+  const emptyBar = empty > 0 ? chalk.gray('░'.repeat(empty)) : '';
+  const percentLabel = `${Math.round(normalized * 100)}%`;
+  const summary = `${completed}/${total}`;
+
+  console.log(
+    `${chalk.blueBright('Plan progress: ')}${filledBar}${emptyBar} ${chalk.bold(percentLabel)} (${summary})`,
+  );
+}
+
 export function renderMessage(message) {
   if (!message) return;
 

--- a/src/cli/runtime.js
+++ b/src/cli/runtime.js
@@ -4,7 +4,7 @@ import { getAutoApproveFlag, getNoHumanFlag, setNoHumanFlag } from '../lib/start
 import { createAgentRuntime } from '../agent/loop.js';
 import { startThinking, stopThinking } from './thinking.js';
 import { createInterface, askHuman, ESCAPE_EVENT } from './io.js';
-import { renderPlan, renderMessage, renderCommand } from './render.js';
+import { renderPlan, renderMessage, renderCommand, renderPlanProgress } from './render.js';
 import { renderRemainingContext } from './status.js';
 import {
   runCommand,
@@ -105,6 +105,9 @@ async function runAgentLoopWithCurrentDependencies() {
           break;
         case 'plan':
           renderPlan(Array.isArray(event.plan) ? event.plan : []);
+          break;
+        case 'plan-progress':
+          renderPlanProgress(event.progress);
           break;
         case 'context-usage':
           if (event.usage) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -20,6 +20,7 @@ import {
   renderPlan,
   renderMessage,
   renderCommand,
+  renderPlanProgress,
 } from '../cli/render.js';
 import { renderRemainingContext } from '../cli/status.js';
 import {
@@ -75,6 +76,7 @@ export {
   renderPlan,
   renderMessage,
   renderCommand,
+  renderPlanProgress,
   renderRemainingContext,
   runCommand,
   runBrowse,
@@ -127,6 +129,7 @@ const exported = {
   renderPlan,
   renderMessage,
   renderCommand,
+  renderPlanProgress,
   renderRemainingContext,
   runCommand,
   runBrowse,

--- a/tests/unit/renderPlan.test.js
+++ b/tests/unit/renderPlan.test.js
@@ -68,4 +68,21 @@ describe('renderPlan', () => {
       logSpy.mockRestore();
     }
   });
+
+  test('renderPlanProgress prints a textual progress bar', async () => {
+    const mod = await loadModule();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      mod.renderPlanProgress({ completedSteps: 2, totalSteps: 5, ratio: 0.4 });
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const output = logSpy.mock.calls[0][0];
+      expect(output).toContain('Plan progress:');
+      expect(output).toContain('40%');
+      expect(output).toContain('2/5');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- compute recursive plan progress in the agent runtime and emit plan-progress events
- render a terminal progress bar for plan updates and expose the helper to consumers
- cover the new utilities and renderer behaviour with targeted unit tests

## Testing
- npm test -- plan.test.js
- npm test -- renderPlan.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e48557eb208328a4b670187ad23528