### PR TITLE
Add literal search option and guard match count in replace command

### DIFF
--- a/prompts/developer.md
+++ b/prompts/developer.md
@@ -125,15 +125,18 @@ All special commands are issued through the `"command"` object in the response J
 
 ### replace
 
-- Use `command.replace` when the assistant needs regex-based find/replace across files.
+- Use `command.replace` when the assistant needs find/replace across files.
 - Required fields:
-  - `pattern`: non-empty regex string (must compile).
+  - Exactly one of:
+    - `raw`: literal string match without regex semantics.
+    - `regex`: non-empty regex string (must compile).
   - `files`: array of relative paths resolved from `cwd`.
 - Optional fields:
   - `replacement`: defaults to empty string.
   - `flags`: string of regex flags; `g` is enforced automatically.
   - `dry_run`: set to true to report matches without modifying files.
   - `encoding`: defaults to `utf8`.
+- The command aborts with an error if more than 100 replacements would be applied across all files.
 - On success the command writes updated file contents unless `dry_run` is true, and reports match counts in stdout.
 - Validation failures or IO errors return `exit_code: 1` with the error message in stderr.
 - Example command payload:
@@ -141,7 +144,7 @@ All special commands are issued through the `"command"` object in the response J
   {
     "command": {
       "replace": {
-        "pattern": "OldAPI",
+        "regex": "OldAPI",
         "replacement": "NewAPI",
         "files": ["src/client.js", "src/server.js"],
         "dry_run": false

--- a/src/commands/context.md
+++ b/src/commands/context.md
@@ -11,7 +11,7 @@
 - `read.js`: streams file contents with path normalization and optional limits.
 - `readSpec.js`: parses shell-style `read` command invocations into normalized specs for the loop and tests.
 - `edit.js`: applies positional edits, creating files/directories as needed.
-- `replace.js`: regex-based multi-file replacement with dry-run support.
+- `replace.js`: multi-file replacement supporting regex or literal search, with dry-run previews and a safety limit on matches.
 - `escapeString.js`: implements `quote_string` / `unquote_string` built-ins via JSON stringification/parsing.
 - `preapproval.js`: evaluates commands against allowlists and per-session approvals.
 - `commandStats.js`: records command usage to XDG cache path.


### PR DESCRIPTION
## Summary
- allow `command.replace` to search by literal strings or regex and reject ambiguous specs
- enforce a safety limit of 100 replacements before writing files
- document the new command shape and extend unit coverage for the updated behaviour

## Testing
- npm test -- replaceCommand
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e48d13992c8328adb7f0b7edfe092d