### PR TITLE
Fix auto-release workflow to bump minor version

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -31,10 +31,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump revision version
+      - name: Bump minor version
         id: version
         run: |
-          tag=$(npm version revision -m "chore(release): %s")
+          tag=$(npm version minor -m "chore(release): %s")
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Push release commit and tag

--- a/.github/workflows/context.md
+++ b/.github/workflows/context.md
@@ -8,7 +8,7 @@ Automation pipelines for CI, releases, and quality checks.
 
 - `test.yml`: runs linting and tests on pull requests.
 - `publish.yml`: publishes `@asynkron/openagent` to npm whenever a GitHub release is published or manually triggered. Requires `id-token: write` so the `npm publish --provenance` step can request an OIDC token and now skips publication if the version already exists on npm.
-- `auto-release.yml`: on every push to `main` (i.e., post-merge), automatically bumps the minor version, tags the release, and creates a GitHub release so that `publish.yml` can push the new version to npm.
+- `auto-release.yml`: on every push to `main` (i.e., post-merge), automatically bumps the minor version (using `npm version minor`), tags the release, and creates a GitHub release so that `publish.yml` can push the new version to npm.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- update the auto-release workflow to bump the npm minor version instead of the non-existent revision
- document that the workflow now uses `npm version minor`

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e4a901e34c8328be08e827404bfa6a