### PR TITLE
Add Git, OS, and linting boot probes

### DIFF
--- a/src/cli/bootProbes/eslintProbe.js
+++ b/src/cli/bootProbes/eslintProbe.js
@@ -1,0 +1,67 @@
+import { createBootProbeResult } from './context.js';
+
+const ESLINT_CONFIG_FILES = [
+  '.eslintrc',
+  '.eslintrc.js',
+  '.eslintrc.cjs',
+  '.eslintrc.mjs',
+  '.eslintrc.json',
+  '.eslintrc.yaml',
+  '.eslintrc.yml',
+  'eslint.config.js',
+  'eslint.config.cjs',
+  'eslint.config.mjs',
+];
+
+// Detects whether ESLint is configured in the project and highlights relevant tooling.
+export const EslintBootProbe = {
+  name: 'ESLint',
+  async run(context) {
+    const details = [];
+    let detected = false;
+
+    const packageJson = await context.readJsonFile('package.json');
+    if (packageJson) {
+      const dependencies = { ...packageJson.dependencies, ...packageJson.devDependencies, ...packageJson.peerDependencies };
+      if (dependencies.eslint) {
+        detected = true;
+        details.push(`package.json declares eslint ${dependencies.eslint}`);
+      }
+      if (packageJson.scripts && packageJson.scripts.lint) {
+        detected = true;
+        details.push(`lint script: ${packageJson.scripts.lint}`);
+      }
+    }
+
+    for (const configFile of ESLINT_CONFIG_FILES) {
+      if (await context.fileExists(configFile)) {
+        detected = true;
+        details.push(`config: ${configFile}`);
+      }
+    }
+
+    if (!detected) {
+      return createBootProbeResult({
+        detected: false,
+        details: ['ESLint configuration not detected'],
+        tooling: 'Add ESLint via `npm install --save-dev eslint` to enable linting.',
+      });
+    }
+
+    const tooling = [
+      '## ESLint helpers',
+      '',
+      '- Run `npx eslint .` to lint the project.',
+      '- Use `--fix` to apply automatic fixes where available.',
+      '- Combine with prettier when format consistency is required.',
+    ].join('\n');
+
+    return createBootProbeResult({
+      detected: true,
+      details,
+      tooling,
+    });
+  },
+};
+
+export default EslintBootProbe;

--- a/src/cli/bootProbes/gitProbe.js
+++ b/src/cli/bootProbes/gitProbe.js
@@ -1,0 +1,79 @@
+import { createBootProbeResult } from './context.js';
+
+// Detects Git repositories and surfaces useful metadata for reasoning about version control.
+export const GitBootProbe = {
+  name: 'Git',
+  async run(context) {
+    const details = [];
+    const toolingSections = [];
+
+    // We consider the probe detected when a .git directory or file is present at the root.
+    const gitDirExists = await context.fileExists('.git');
+    const gitFileExists = await context.fileExists('.git/config');
+    const detected = gitDirExists || gitFileExists;
+
+    if (!detected) {
+      const gitAvailable = await context.commandExists('git');
+      if (!gitAvailable) {
+        return createBootProbeResult({
+          detected: false,
+          details: ['git CLI not detected in PATH'],
+          tooling: 'Install Git to enable version control operations.',
+        });
+      }
+
+      return createBootProbeResult({
+        detected: false,
+        details: ['No .git directory detected in workspace root'],
+        tooling: 'Run `git init` to create a repository when needed.',
+      });
+    }
+
+    details.push('Git repository detected');
+
+    // Capture the current branch by reading HEAD when possible. We avoid running external
+    // commands to keep the probe side-effect free.
+    const headContents = await context.readTextFile('.git/HEAD');
+    if (headContents) {
+      const refMatch = headContents.match(/ref:\s*(.+)/);
+      if (refMatch) {
+        details.push(`HEAD → ${refMatch[1].trim()}`);
+      } else {
+        details.push(`Detached HEAD (${headContents.trim()})`);
+      }
+    }
+
+    // Parse the first remote entry from .git/config to inform the agent about upstream state.
+    const gitConfig = await context.readTextFile('.git/config');
+    if (gitConfig) {
+      const remoteMatch = gitConfig.match(/\[remote "([^"]+)"\][^\[]+?url\s*=\s*(.+)/);
+      if (remoteMatch) {
+        details.push(`remote ${remoteMatch[1]} → ${remoteMatch[2].trim()}`);
+      }
+    }
+
+    // The git CLI itself is usually available, but we still surface that detail to hint at
+    // possible follow-up commands.
+    const gitAvailable = await context.commandExists('git');
+    toolingSections.push(gitAvailable ? 'git CLI detected in PATH.' : 'git CLI missing from PATH.');
+
+    const tooling = [
+      '## Git helpers',
+      '',
+      '- Use `git status --short` to inspect pending changes before committing.',
+      '- Use `git diff` to review modifications.',
+      '- Use `git branch --show-current` to confirm the active branch.',
+      '- Use `git remote -v` to inspect remotes.',
+      '',
+      ...toolingSections,
+    ].join('\n');
+
+    return createBootProbeResult({
+      detected: true,
+      details,
+      tooling,
+    });
+  },
+};
+
+export default GitBootProbe;

--- a/src/cli/bootProbes/index.js
+++ b/src/cli/bootProbes/index.js
@@ -6,12 +6,20 @@ import JavaScriptBootProbe from './javascriptProbe.js';
 import TypeScriptBootProbe from './typescriptProbe.js';
 import PythonBootProbe from './pythonProbe.js';
 import DotNetBootProbe from './dotnetProbe.js';
+import GitBootProbe from './gitProbe.js';
+import OperatingSystemBootProbe from './operatingSystemProbe.js';
+import EslintBootProbe from './eslintProbe.js';
+import PrettierBootProbe from './prettierProbe.js';
 
 const DEFAULT_PROBES = [
   JavaScriptBootProbe,
   TypeScriptBootProbe,
   PythonBootProbe,
   DotNetBootProbe,
+  GitBootProbe,
+  OperatingSystemBootProbe,
+  EslintBootProbe,
+  PrettierBootProbe,
 ];
 
 export function registerBootProbe(probe) {

--- a/src/cli/bootProbes/operatingSystemProbe.js
+++ b/src/cli/bootProbes/operatingSystemProbe.js
@@ -1,0 +1,48 @@
+import os from 'node:os';
+
+import { createBootProbeResult } from './context.js';
+
+// Summarises host operating system characteristics to aid downstream planning.
+export const OperatingSystemBootProbe = {
+  name: 'Operating system',
+  async run() {
+    const details = [];
+
+    // Present basic OS identity information.
+    details.push(`${os.type()} ${os.release()} (${os.platform()}/${os.arch()})`);
+
+    const cpuInfo = os.cpus();
+    if (cpuInfo && cpuInfo.length > 0) {
+      const model = cpuInfo[0].model ? cpuInfo[0].model.trim() : 'Unknown CPU';
+      details.push(`CPU: ${cpuInfo.length} × ${model}`);
+    }
+
+    const totalMem = os.totalmem();
+    const freeMem = os.freemem();
+    if (Number.isFinite(totalMem) && Number.isFinite(freeMem)) {
+      const toGB = (bytes) => Math.round((bytes / 1024 / 1024 / 1024) * 10) / 10;
+      details.push(`Memory: ${toGB(freeMem)}GB free / ${toGB(totalMem)}GB total`);
+    }
+
+    const shell = process.env.SHELL || process.env.ComSpec;
+    if (shell) {
+      details.push(`Shell: ${shell}`);
+    }
+
+    const tooling = [
+      '## Operating system insights',
+      '',
+      '- Consider platform-specific tooling when planning actions.',
+      '- Use detected CPU and memory information to estimate resource heavy tasks.',
+      '- Shell information can help decide between POSIX and Windows command syntax.',
+    ].join('\n');
+
+    return createBootProbeResult({
+      detected: true,
+      details,
+      tooling,
+    });
+  },
+};
+
+export default OperatingSystemBootProbe;

--- a/src/cli/bootProbes/prettierProbe.js
+++ b/src/cli/bootProbes/prettierProbe.js
@@ -1,0 +1,72 @@
+import { createBootProbeResult } from './context.js';
+
+const PRETTIER_CONFIG_FILES = [
+  '.prettierrc',
+  '.prettierrc.js',
+  '.prettierrc.cjs',
+  '.prettierrc.mjs',
+  '.prettierrc.json',
+  '.prettierrc.yaml',
+  '.prettierrc.yml',
+  '.prettierrc.toml',
+  'prettier.config.js',
+  'prettier.config.cjs',
+  'prettier.config.mjs',
+];
+
+// Detects whether Prettier is configured so the agent can rely on automated formatting.
+export const PrettierBootProbe = {
+  name: 'Prettier',
+  async run(context) {
+    const details = [];
+    let detected = false;
+
+    const packageJson = await context.readJsonFile('package.json');
+    if (packageJson) {
+      const dependencies = { ...packageJson.dependencies, ...packageJson.devDependencies, ...packageJson.peerDependencies };
+      if (dependencies.prettier) {
+        detected = true;
+        details.push(`package.json declares prettier ${dependencies.prettier}`);
+      }
+      if (packageJson.scripts && packageJson.scripts.format) {
+        detected = true;
+        details.push(`format script: ${packageJson.scripts.format}`);
+      }
+      if (packageJson.prettier) {
+        detected = true;
+        details.push('package.json contains prettier configuration');
+      }
+    }
+
+    for (const configFile of PRETTIER_CONFIG_FILES) {
+      if (await context.fileExists(configFile)) {
+        detected = true;
+        details.push(`config: ${configFile}`);
+      }
+    }
+
+    if (!detected) {
+      return createBootProbeResult({
+        detected: false,
+        details: ['Prettier configuration not detected'],
+        tooling: 'Install Prettier with `npm install --save-dev prettier` to enable formatting.',
+      });
+    }
+
+    const tooling = [
+      '## Prettier helpers',
+      '',
+      '- Run `npx prettier --check .` to verify formatting.',
+      '- Use `--write` to apply formatting changes automatically.',
+      '- Integrate Prettier with ESLint or editors for consistent style.',
+    ].join('\n');
+
+    return createBootProbeResult({
+      detected: true,
+      details,
+      tooling,
+    });
+  },
+};
+
+export default PrettierBootProbe;

--- a/tests/unit/bootProbes.test.js
+++ b/tests/unit/bootProbes.test.js
@@ -1,12 +1,16 @@
-import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 
 import { formatBootProbeSummary, runBootProbes } from '../../src/cli/bootProbes/index.js';
 
 async function createTempDir(prefix = 'boot-probe-test-') {
   return mkdtemp(join(tmpdir(), prefix));
 }
+
+const execFileAsync = promisify(execFile);
 
 function normalizeLine(value) {
   return (value || '')
@@ -64,6 +68,83 @@ describe('boot probes', () => {
       }
       expect(normalizeLine(lines.at(-1))).toMatch(/^OS:/);
       expect(summary.split('\n').at(-1)).toMatch(/^- OS:/);
+    });
+  });
+
+  it('detects git repositories and surfaces branch information', async () => {
+    await withTempDir(async (dir) => {
+      // Create a basic git repository to exercise the GitBootProbe without relying on fixtures.
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await writeFile(join(dir, 'README.md'), '# Sample repo\n', 'utf8');
+      await execFileAsync('git', ['add', 'README.md'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'Initial commit'], { cwd: dir });
+
+      const results = await runBootProbes({ cwd: dir, emit: () => {} });
+      const gitResult = results.find((result) => result.probe === 'Git');
+
+      expect(gitResult).toBeDefined();
+      expect(gitResult.detected).toBe(true);
+      expect(gitResult.details.some((detail) => detail.includes('HEAD'))).toBe(true);
+      expect(gitResult.tooling).toContain('Git helpers');
+    });
+  });
+
+  it('detects ESLint configuration from package.json and config files', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({
+          name: 'linted-app',
+          devDependencies: { eslint: '^9.0.0' },
+          scripts: { lint: 'eslint .' },
+        }),
+        'utf8',
+      );
+      await writeFile(join(dir, '.eslintrc.json'), JSON.stringify({ extends: ['eslint:recommended'] }), 'utf8');
+
+      const results = await runBootProbes({ cwd: dir, emit: () => {} });
+      const eslintResult = results.find((result) => result.probe === 'ESLint');
+
+      expect(eslintResult).toBeDefined();
+      expect(eslintResult.detected).toBe(true);
+      expect(eslintResult.details).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('package.json declares eslint'),
+          expect.stringContaining('lint script'),
+          expect.stringContaining('config: .eslintrc.json'),
+        ]),
+      );
+      expect(eslintResult.tooling).toContain('ESLint helpers');
+    });
+  });
+
+  it('detects Prettier configuration from scripts and config files', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({
+          name: 'formatted-app',
+          devDependencies: { prettier: '^3.0.0' },
+          scripts: { format: 'prettier --write .' },
+        }),
+        'utf8',
+      );
+      await mkdir(join(dir, '.config'), { recursive: true });
+      await writeFile(join(dir, '.prettierrc'), JSON.stringify({ semi: false }), 'utf8');
+
+      const results = await runBootProbes({ cwd: dir, emit: () => {} });
+      const prettierResult = results.find((result) => result.probe === 'Prettier');
+
+      expect(prettierResult).toBeDefined();
+      expect(prettierResult.detected).toBe(true);
+      expect(prettierResult.details).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('package.json declares prettier'),
+          expect.stringContaining('format script'),
+          expect.stringContaining('config: .prettierrc'),
+        ]),
+      );
+      expect(prettierResult.tooling).toContain('Prettier helpers');
     });
   });
 });


### PR DESCRIPTION
## Summary
- add boot probes for Git, operating system, ESLint, and Prettier detection
- register the new probes so boot probe runs surface repo, platform, and formatting context
- extend boot probe tests to cover the new probes and ensure git metadata is captured

## Testing
- npm test -- bootProbes

------
https://chatgpt.com/codex/tasks/task_e_68e5342de310832881bc2bd6863bc342