### PR TITLE
Add boot probes for Go, Rust, JVM, and containers

### DIFF
--- a/src/cli/bootProbes/containerProbe.js
+++ b/src/cli/bootProbes/containerProbe.js
@@ -1,0 +1,89 @@
+import { createBootProbeResult } from './context.js';
+
+const CONTAINER_FILES = [
+  'Dockerfile',
+  'Dockerfile.dev',
+  'Containerfile',
+  'docker-compose.yml',
+  'docker-compose.yaml',
+  'compose.yml',
+  'compose.yaml',
+  '.dockerignore',
+];
+
+const DEVCONTAINER_FILES = [
+  '.devcontainer/devcontainer.json',
+  '.devcontainer/docker-compose.yml',
+  '.devcontainer/docker-compose.yaml',
+];
+
+const TOOL_CHECKS = [
+  { name: 'docker' },
+  { name: 'docker-compose', label: 'docker-compose' },
+  { name: 'podman' },
+  { name: 'nerdctl' },
+];
+
+function formatExampleEntries(entries) {
+  const sample = entries.slice(0, 3).map((entry) => entry.name).join(', ');
+  return entries.length > 3 ? `${sample}, …` : sample;
+}
+
+export const ContainerBootProbe = {
+  name: 'Container / DevOps',
+  async run(context) {
+    const details = [];
+    let detected = false;
+
+    for (const file of CONTAINER_FILES) {
+      if (await context.fileExists(file)) {
+        detected = true;
+        details.push(file);
+      }
+    }
+
+    for (const file of DEVCONTAINER_FILES) {
+      if (await context.fileExists(file)) {
+        detected = true;
+        details.push(file);
+      }
+    }
+
+    if (await context.fileExists('.devcontainer')) {
+      const entries = await context.readDirEntries('.devcontainer');
+      if (entries.length > 0) {
+        detected = true;
+        details.push(`.devcontainer/ (${formatExampleEntries(entries)})`);
+      }
+    }
+
+    const toolAvailability = await Promise.all(
+      TOOL_CHECKS.map(async ({ name, command = name, label = name }) => {
+        const available = await context.commandExists(command);
+        const summary = available
+          ? `${label} is installed and ready to use`
+          : `${label} is not installed`;
+        return { name: label, available, summary };
+      })
+    );
+
+    for (const tool of toolAvailability) {
+      details.push(tool.summary);
+    }
+
+    const hasHelpfulTooling = detected || toolAvailability.some((tool) => tool.available);
+
+    const tooling = hasHelpfulTooling
+      ? [
+          'Dockerfiles or devcontainers enable reproducible environments; docker-compose (or podman/nerdctl) orchestrates multi-service setups.',
+          '',
+          '### Tool availability',
+          ...toolAvailability.map((tool) => `- ${tool.summary}`),
+        ].join('\n')
+      : '';
+
+    return createBootProbeResult({ detected, details, tooling });
+  },
+};
+
+export default ContainerBootProbe;

--- a/src/cli/bootProbes/goProbe.js
+++ b/src/cli/bootProbes/goProbe.js
@@ -1,0 +1,84 @@
+import { createBootProbeResult } from './context.js';
+
+// Canonical files that normally appear in Go workspaces.
+const GO_FILES = [
+  'go.mod',
+  'go.sum',
+  'go.work',
+  'go.work.sum',
+  'Gopkg.toml',
+  'Gopkg.lock',
+];
+
+// Directory layouts that often signal multi-package Go projects.
+const GO_DIRECTORIES = ['cmd', 'pkg', 'internal'];
+
+const TOOL_CHECKS = [
+  { name: 'go' },
+  { name: 'gofmt' },
+  { name: 'goimports' },
+  { name: 'golangci-lint', label: 'golangci-lint' },
+];
+
+function formatExampleEntries(entries) {
+  const sample = entries.slice(0, 3).map((entry) => entry.name).join(', ');
+  return entries.length > 3 ? `${sample}, …` : sample;
+}
+
+export const GoBootProbe = {
+  name: 'Go',
+  async run(context) {
+    const details = [];
+    let detected = false;
+
+    for (const file of GO_FILES) {
+      if (await context.fileExists(file)) {
+        detected = true;
+        details.push(file);
+      }
+    }
+
+    const rootEntries = await context.getRootEntries();
+    const goFiles = rootEntries.filter((entry) => entry.isFile?.() && /\.go$/i.test(entry.name));
+    if (goFiles.length > 0) {
+      detected = true;
+      details.push(`Go source files (${formatExampleEntries(goFiles)})`);
+    }
+
+    for (const directory of GO_DIRECTORIES) {
+      if (await context.fileExists(directory)) {
+        detected = true;
+        details.push(`${directory}/ directory`);
+      }
+    }
+
+    const toolAvailability = await Promise.all(
+      TOOL_CHECKS.map(async ({ name, command = name, label = name }) => {
+        const available = await context.commandExists(command);
+        const summary = available
+          ? `${label} is installed and ready to use`
+          : `${label} is not installed`;
+        return { name: label, available, summary };
+      })
+    );
+
+    for (const tool of toolAvailability) {
+      details.push(tool.summary);
+    }
+
+    const hasHelpfulTooling = detected || toolAvailability.some((tool) => tool.available);
+
+    const tooling = hasHelpfulTooling
+      ? [
+          'Go modules expect go build/test/vet; gofmt or goimports keep formatting consistent, and golangci-lint aggregates lint passes.',
+          '',
+          '### Tool availability',
+          ...toolAvailability.map((tool) => `- ${tool.summary}`),
+        ].join('\n')
+      : '';
+
+    return createBootProbeResult({ detected, details, tooling });
+  },
+};
+
+export default GoBootProbe;

--- a/src/cli/bootProbes/index.js
+++ b/src/cli/bootProbes/index.js
@@ -11,6 +11,10 @@ import GitBootProbe from './gitProbe.js';
 import OperatingSystemBootProbe from './operatingSystemProbe.js';
 import EslintBootProbe from './eslintProbe.js';
 import PrettierBootProbe from './prettierProbe.js';
+import GoBootProbe from './goProbe.js';
+import RustBootProbe from './rustProbe.js';
+import JvmBootProbe from './jvmProbe.js';
+import ContainerBootProbe from './containerProbe.js';
 
 const DEFAULT_PROBES = [
   JavaScriptBootProbe,
@@ -18,7 +22,11 @@ const DEFAULT_PROBES = [
   TypeScriptBootProbe,
   PythonBootProbe,
   DotNetBootProbe,
+  GoBootProbe,
+  RustBootProbe,
+  JvmBootProbe,
   GitBootProbe,
+  ContainerBootProbe,
   OperatingSystemBootProbe,
   EslintBootProbe,
   PrettierBootProbe,

--- a/src/cli/bootProbes/jvmProbe.js
+++ b/src/cli/bootProbes/jvmProbe.js
@@ -1,0 +1,105 @@
+import { createBootProbeResult } from './context.js';
+
+const BUILD_FILES = [
+  'pom.xml',
+  'build.gradle',
+  'build.gradle.kts',
+  'settings.gradle',
+  'settings.gradle.kts',
+  'gradle.properties',
+];
+
+const WRAPPER_SCRIPTS = ['mvnw', 'mvnw.cmd', 'gradlew', 'gradlew.bat'];
+
+const SOURCE_DIRECTORIES = [
+  'src/main/java',
+  'src/test/java',
+  'src/main/kotlin',
+  'src/test/kotlin',
+  'src/main/scala',
+  'src/test/scala',
+];
+
+const TOOL_CHECKS = [
+  { name: 'java' },
+  { name: 'javac' },
+  { name: 'mvn', label: 'maven (mvn)' },
+  { name: 'gradle' },
+];
+
+function formatExampleEntries(entries) {
+  const sample = entries.slice(0, 3).map((entry) => entry.name).join(', ');
+  return entries.length > 3 ? `${sample}, …` : sample;
+}
+
+export const JvmBootProbe = {
+  name: 'Java / JVM',
+  async run(context) {
+    const details = [];
+    let detected = false;
+
+    for (const file of BUILD_FILES) {
+      if (await context.fileExists(file)) {
+        detected = true;
+        details.push(file);
+      }
+    }
+
+    for (const script of WRAPPER_SCRIPTS) {
+      if (await context.fileExists(script)) {
+        detected = true;
+        details.push(`${script} wrapper`);
+      }
+    }
+
+    for (const sourceDir of SOURCE_DIRECTORIES) {
+      if (await context.fileExists(sourceDir)) {
+        detected = true;
+        const label = sourceDir.replace(/\\+/g, '/');
+        const entries = await context.readDirEntries(sourceDir);
+        const files = entries.filter((entry) => entry.isFile?.());
+        if (files.length > 0) {
+          details.push(`${label} (${formatExampleEntries(files)})`);
+        } else {
+          details.push(label);
+        }
+      }
+    }
+
+    const rootEntries = await context.getRootEntries();
+    const javaFiles = rootEntries.filter((entry) => entry.isFile?.() && /\.(java|kt|kts|scala)$/i.test(entry.name));
+    if (javaFiles.length > 0) {
+      detected = true;
+      details.push(`JVM sources (${formatExampleEntries(javaFiles)})`);
+    }
+
+    const toolAvailability = await Promise.all(
+      TOOL_CHECKS.map(async ({ name, command = name, label = name }) => {
+        const available = await context.commandExists(command);
+        const summary = available
+          ? `${label} is installed and ready to use`
+          : `${label} is not installed`;
+        return { name: label, available, summary };
+      })
+    );
+
+    for (const tool of toolAvailability) {
+      details.push(tool.summary);
+    }
+
+    const hasHelpfulTooling = detected || toolAvailability.some((tool) => tool.available);
+
+    const tooling = hasHelpfulTooling
+      ? [
+          'Use Maven or Gradle wrappers for builds/tests; ensure Java and javac match the targeted bytecode level.',
+          '',
+          '### Tool availability',
+          ...toolAvailability.map((tool) => `- ${tool.summary}`),
+        ].join('\n')
+      : '';
+
+    return createBootProbeResult({ detected, details, tooling });
+  },
+};
+
+export default JvmBootProbe;

--- a/src/cli/bootProbes/rustProbe.js
+++ b/src/cli/bootProbes/rustProbe.js
@@ -1,0 +1,86 @@
+import { createBootProbeResult } from './context.js';
+
+// Rust projects expose these well-known files in their workspace root.
+const RUST_FILES = ['Cargo.toml', 'Cargo.lock', 'rust-toolchain', 'rust-toolchain.toml'];
+
+// Directories commonly present in Cargo workspaces.
+const RUST_DIRECTORIES = ['src', 'tests', 'benches', 'examples'];
+
+const TOOL_CHECKS = [
+  { name: 'cargo' },
+  { name: 'rustc' },
+  { name: 'rustfmt' },
+  { name: 'cargo-clippy', label: 'cargo-clippy' },
+  { name: 'rustup' },
+];
+
+function formatExampleEntries(entries) {
+  const sample = entries.slice(0, 3).map((entry) => entry.name).join(', ');
+  return entries.length > 3 ? `${sample}, …` : sample;
+}
+
+export const RustBootProbe = {
+  name: 'Rust',
+  async run(context) {
+    const details = [];
+    let detected = false;
+
+    for (const file of RUST_FILES) {
+      if (await context.fileExists(file)) {
+        detected = true;
+        details.push(file);
+      }
+    }
+
+    for (const directory of RUST_DIRECTORIES) {
+      if (await context.fileExists(directory)) {
+        detected = true;
+        details.push(`${directory}/ directory`);
+
+        if (directory === 'src') {
+          const srcEntries = await context.readDirEntries('src');
+          const rustFiles = srcEntries.filter((entry) => entry.isFile?.() && /\.rs$/i.test(entry.name));
+          if (rustFiles.length > 0) {
+            details.push(`Rust sources (${formatExampleEntries(rustFiles)})`);
+          }
+        }
+      }
+    }
+
+    const rootEntries = await context.getRootEntries();
+    const rustFiles = rootEntries.filter((entry) => entry.isFile?.() && /\.rs$/i.test(entry.name));
+    if (rustFiles.length > 0) {
+      detected = true;
+      details.push(`Root Rust files (${formatExampleEntries(rustFiles)})`);
+    }
+
+    const toolAvailability = await Promise.all(
+      TOOL_CHECKS.map(async ({ name, command = name, label = name }) => {
+        const available = await context.commandExists(command);
+        const summary = available
+          ? `${label} is installed and ready to use`
+          : `${label} is not installed`;
+        return { name: label, available, summary };
+      })
+    );
+
+    for (const tool of toolAvailability) {
+      details.push(tool.summary);
+    }
+
+    const hasHelpfulTooling = detected || toolAvailability.some((tool) => tool.available);
+
+    const tooling = hasHelpfulTooling
+      ? [
+          'Cargo orchestrates builds/tests; rustfmt formats code, and cargo-clippy provides linting. rustup manages toolchains.',
+          '',
+          '### Tool availability',
+          ...toolAvailability.map((tool) => `- ${tool.summary}`),
+        ].join('\n')
+      : '';
+
+    return createBootProbeResult({ detected, details, tooling });
+  },
+};
+
+export default RustBootProbe;

--- a/src/cli/context.md
+++ b/src/cli/context.md
@@ -7,7 +7,7 @@
 ## Modules
 
 
-- `bootProbes/`: language/OS detectors that run before the agent loop to surface repo hints in CLI mode, include recommended tooling blurbs for detected stacks, and export a formatter so the detected context can enrich the system prompt. The JavaScript probe also reports whether helper refactoring binaries (comby, jscodeshift, ast-grep, acorn) are already available on the PATH, and the Node.js probe summarises runtime/package-manager availability (node, npx, npm, pnpm, yarn, bun).
+- `bootProbes/`: language/OS detectors that run before the agent loop to surface repo hints in CLI mode, include recommended tooling blurbs for detected stacks, and export a formatter so the detected context can enrich the system prompt. The JavaScript probe also reports whether helper refactoring binaries (comby, jscodeshift, ast-grep, acorn) are already available on the PATH, the Node.js probe summarises runtime/package-manager availability (node, npx, npm, pnpm, yarn, bun), and additional probes now cover Go, Rust, JVM build tooling, and containerisation signals.
 - `runtime.js`: wires the agent runtime to the terminal renderer and exports `agentLoop` plus command tracking helpers used by the CLI entry point.
 - `io.js`: readline wrapper with ESC detection (emits `ESCAPE_EVENT`, cancels active operations, highlights prompts).
 - `render.js`: Markdown-based renderer for plans/messages/command summaries and the plan progress bar.


### PR DESCRIPTION
## Summary
- add boot probes that detect Go, Rust, JVM build tooling, and containerisation hints while reporting key CLI helpers
- extend boot probe unit tests with coverage for the new detectors and richer stub contexts
- document the broader boot probe coverage in the CLI context notes

## Testing
- npm test -- bootProbes

------
https://chatgpt.com/codex/tasks/task_e_68e5404b61048328b991a8ef114c027a