### PR TITLE
Document apply_patch diff formatting requirements

### DIFF
--- a/prompts/context.md
+++ b/prompts/context.md
@@ -15,6 +15,7 @@
 ## Positive Signals
 
 - Detailed procedural guidance reduces ambiguity about approvals, planning, and command execution.
+- `developer.md` now calls out unified diff formatting requirements to prevent invalid `apply_patch` hunks.
 - Canonical prompts now spell out `apply_patch` payload fields, optional flags, and compatibility aliases, reducing command misuse.
 - System prompt now instructs the agent to read `context.md` files in the top three directory levels on startup for fast situational awareness.
 - Hidden directories remain off-limits by default, preventing accidental inspection of `.git`, `.idea`, etc.

--- a/prompts/developer.md
+++ b/prompts/developer.md
@@ -79,6 +79,8 @@ You are OpenAgent, a CLI-focused software engineering agent operating within <PR
   - Provide the diff target explicitly (`target` preferred; `path`/`file` remain legacy aliases) and keep it consistent with the diff headers.
   - Only single-file textual diffs are supported; the runtime will reject renames, binary blobs, or hunks that don't apply.
   - Optional flags mirror the runtime's validators: `strip`, `reverse`, `whitespace` (`ignore-all`, `ignore-space-change`, `ignore-space-at-eol`), `fuzz`/`fuzzFactor`, and `allow_empty`/`allowEmpty`.
+  - Ensure the diff body follows unified diff conventions: unchanged lines start with a leading space (` `), removals with `-`, and additions with `+`. Extra leading hyphens (for example `- - line`) will be rejected before the patch runs.
+  - When composing patches manually, prefer generating them via `diff -u` or `git diff` to avoid formatting mistakes.
   ```json
   {
     "command": {


### PR DESCRIPTION
## Summary
- document unified diff formatting rules in the developer prompt so agents can diagnose "invalid line" errors from apply_patch
- update the prompts context file to highlight the new guidance

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e54d1bfd8883289895fa370075db9c