### PR TITLE
Limit boot probe tooling output to installed tools

### DIFF
--- a/src/cli/bootProbes/containerProbe.js
+++ b/src/cli/bootProbes/containerProbe.js
@@ -67,19 +67,28 @@ export const ContainerBootProbe = {
       })
     );
 
-    for (const tool of toolAvailability) {
+    const installedTools = toolAvailability.filter((tool) => tool.available);
+
+    for (const tool of installedTools) {
       details.push(tool.summary);
     }
 
-    const hasHelpfulTooling = detected || toolAvailability.some((tool) => tool.available);
+    const hasHelpfulTooling = detected || installedTools.length > 0;
 
     const tooling = hasHelpfulTooling
-      ? [
-          'Dockerfiles or devcontainers enable reproducible environments; docker-compose (or podman/nerdctl) orchestrates multi-service setups.',
-          '',
-          '### Tool availability',
-          ...toolAvailability.map((tool) => `- ${tool.summary}`),
-        ].join('\n')
+      ? (() => {
+          const sections = [
+            'Dockerfiles or devcontainers enable reproducible environments; docker-compose (or podman/nerdctl) orchestrates multi-service setups.',
+          ];
+
+          if (installedTools.length > 0) {
+            sections.push('');
+            sections.push('### Tool availability');
+            sections.push(...installedTools.map((tool) => `- ${tool.summary}`));
+          }
+
+          return sections.join('\n');
+        })()
       : '';
 
     return createBootProbeResult({ detected, details, tooling });

--- a/src/cli/bootProbes/goProbe.js
+++ b/src/cli/bootProbes/goProbe.js
@@ -62,19 +62,28 @@ export const GoBootProbe = {
       })
     );
 
-    for (const tool of toolAvailability) {
+    const installedTools = toolAvailability.filter((tool) => tool.available);
+
+    for (const tool of installedTools) {
       details.push(tool.summary);
     }
 
-    const hasHelpfulTooling = detected || toolAvailability.some((tool) => tool.available);
+    const hasHelpfulTooling = detected || installedTools.length > 0;
 
     const tooling = hasHelpfulTooling
-      ? [
-          'Go modules expect go build/test/vet; gofmt or goimports keep formatting consistent, and golangci-lint aggregates lint passes.',
-          '',
-          '### Tool availability',
-          ...toolAvailability.map((tool) => `- ${tool.summary}`),
-        ].join('\n')
+      ? (() => {
+          const sections = [
+            'Go modules expect go build/test/vet; gofmt or goimports keep formatting consistent, and golangci-lint aggregates lint passes.',
+          ];
+
+          if (installedTools.length > 0) {
+            sections.push('');
+            sections.push('### Tool availability');
+            sections.push(...installedTools.map((tool) => `- ${tool.summary}`));
+          }
+
+          return sections.join('\n');
+        })()
       : '';
 
     return createBootProbeResult({ detected, details, tooling });

--- a/src/cli/bootProbes/javascriptProbe.js
+++ b/src/cli/bootProbes/javascriptProbe.js
@@ -84,36 +84,48 @@ export const JavaScriptBootProbe = {
       })
     );
 
-    for (const tool of toolAvailability) {
+    const installedTools = toolAvailability.filter((tool) => tool.available);
+
+    for (const tool of installedTools) {
       // Surface each CLI tool's readiness in the probe details so the agent can reason about them immediately.
       details.push(tool.summary);
     }
 
-    const tooling = detected || toolAvailability.some((tool) => tool.available)
-      ? [
-          '## Recommended refactoring tools for JavaScript:',
-          '',
-          '### jscodeshift',
-          'https://github.com/facebook/jscodeshift',
-          '',
-          '### ast-grep',
-          'https://ast-grep.github.io/',
-          '',
-          '### comby',
-          'https://comby.dev/',
-          'https://github.com/comby-tools/comby',
-          '',
-          '### acorn',
-          'https://github.com/acornjs/acorn',
-          '',
-          '### Tool availability',
-          ...toolAvailability.map((tool) => `- ${tool.summary}`),
-          '',
-          'Check for existence on client computer.',
-          'Ask user if you may install them when missing.',
-          'Check help output per tool to learn how to use them.',
-          'Prefer proper refactoring tools over manual edits.',
-        ].join('\n')
+    const hasHelpfulTooling = detected || installedTools.length > 0;
+
+    const tooling = hasHelpfulTooling
+      ? (() => {
+          const sections = [
+            '## Recommended refactoring tools for JavaScript:',
+            '',
+            '### jscodeshift',
+            'https://github.com/facebook/jscodeshift',
+            '',
+            '### ast-grep',
+            'https://ast-grep.github.io/',
+            '',
+            '### comby',
+            'https://comby.dev/',
+            'https://github.com/comby-tools/comby',
+            '',
+            '### acorn',
+            'https://github.com/acornjs/acorn',
+            '',
+          ];
+
+          if (installedTools.length > 0) {
+            sections.push('### Tool availability');
+            sections.push(...installedTools.map((tool) => `- ${tool.summary}`));
+            sections.push('');
+          }
+
+          sections.push('Check for existence on client computer.');
+          sections.push('Ask user if you may install them when missing.');
+          sections.push('Check help output per tool to learn how to use them.');
+          sections.push('Prefer proper refactoring tools over manual edits.');
+
+          return sections.join('\n');
+        })()
       : '';
 
     return createBootProbeResult({ detected, details, tooling });

--- a/src/cli/bootProbes/jvmProbe.js
+++ b/src/cli/bootProbes/jvmProbe.js
@@ -83,19 +83,28 @@ export const JvmBootProbe = {
       })
     );
 
-    for (const tool of toolAvailability) {
+    const installedTools = toolAvailability.filter((tool) => tool.available);
+
+    for (const tool of installedTools) {
       details.push(tool.summary);
     }
 
-    const hasHelpfulTooling = detected || toolAvailability.some((tool) => tool.available);
+    const hasHelpfulTooling = detected || installedTools.length > 0;
 
     const tooling = hasHelpfulTooling
-      ? [
-          'Use Maven or Gradle wrappers for builds/tests; ensure Java and javac match the targeted bytecode level.',
-          '',
-          '### Tool availability',
-          ...toolAvailability.map((tool) => `- ${tool.summary}`),
-        ].join('\n')
+      ? (() => {
+          const sections = [
+            'Use Maven or Gradle wrappers for builds/tests; ensure Java and javac match the targeted bytecode level.',
+          ];
+
+          if (installedTools.length > 0) {
+            sections.push('');
+            sections.push('### Tool availability');
+            sections.push(...installedTools.map((tool) => `- ${tool.summary}`));
+          }
+
+          return sections.join('\n');
+        })()
       : '';
 
     return createBootProbeResult({ detected, details, tooling });

--- a/src/cli/bootProbes/nodeProbe.js
+++ b/src/cli/bootProbes/nodeProbe.js
@@ -22,17 +22,25 @@ export const NodeBootProbe = {
       })
     );
 
-    const details = toolAvailability.map((tool) => tool.summary);
-    const detected = toolAvailability.some((tool) => tool.available);
+    const installedTools = toolAvailability.filter((tool) => tool.available);
+    const details = installedTools.map((tool) => tool.summary);
+    const detected = installedTools.length > 0;
 
     const tooling = detected
-      ? [
-          'Use nvm, fnm, or asdf to manage Node.js versions when multiple runtimes are required.',
-          'npm is bundled with Node.js; prefer package managers already present (npm/pnpm/yarn/bun) to avoid redundant installs.',
-          '',
-          '### Tool availability',
-          ...toolAvailability.map((tool) => `- ${tool.summary}`),
-        ].join('\n')
+      ? (() => {
+          const sections = [
+            'Use nvm, fnm, or asdf to manage Node.js versions when multiple runtimes are required.',
+            'npm is bundled with Node.js; prefer package managers already present (npm/pnpm/yarn/bun) to avoid redundant installs.',
+          ];
+
+          if (installedTools.length > 0) {
+            sections.push('');
+            sections.push('### Tool availability');
+            sections.push(...installedTools.map((tool) => `- ${tool.summary}`));
+          }
+
+          return sections.join('\n');
+        })()
       : '';
 
     return createBootProbeResult({ detected, details, tooling });

--- a/src/cli/bootProbes/pythonProbe.js
+++ b/src/cli/bootProbes/pythonProbe.js
@@ -83,19 +83,28 @@ export const PythonBootProbe = {
       })
     );
 
-    for (const tool of toolAvailability) {
+    const installedTools = toolAvailability.filter((tool) => tool.available);
+
+    for (const tool of installedTools) {
       details.push(tool.summary);
     }
 
-    const hasHelpfulTooling = detected || toolAvailability.some((tool) => tool.available);
+    const hasHelpfulTooling = detected || installedTools.length > 0;
 
     const tooling = hasHelpfulTooling
-      ? [
-          'Prefer virtualenv or Poetry for environments, pip for packages, and pytest plus black/ruff for testing and linting.',
-          '',
-          '### Tool availability',
-          ...toolAvailability.map((tool) => `- ${tool.summary}`),
-        ].join('\n')
+      ? (() => {
+          const sections = [
+            'Prefer virtualenv or Poetry for environments, pip for packages, and pytest plus black/ruff for testing and linting.',
+          ];
+
+          if (installedTools.length > 0) {
+            sections.push('');
+            sections.push('### Tool availability');
+            sections.push(...installedTools.map((tool) => `- ${tool.summary}`));
+          }
+
+          return sections.join('\n');
+        })()
       : '';
 
     return createBootProbeResult({ detected, details, tooling });

--- a/src/cli/bootProbes/rustProbe.js
+++ b/src/cli/bootProbes/rustProbe.js
@@ -64,19 +64,28 @@ export const RustBootProbe = {
       })
     );
 
-    for (const tool of toolAvailability) {
+    const installedTools = toolAvailability.filter((tool) => tool.available);
+
+    for (const tool of installedTools) {
       details.push(tool.summary);
     }
 
-    const hasHelpfulTooling = detected || toolAvailability.some((tool) => tool.available);
+    const hasHelpfulTooling = detected || installedTools.length > 0;
 
     const tooling = hasHelpfulTooling
-      ? [
-          'Cargo orchestrates builds/tests; rustfmt formats code, and cargo-clippy provides linting. rustup manages toolchains.',
-          '',
-          '### Tool availability',
-          ...toolAvailability.map((tool) => `- ${tool.summary}`),
-        ].join('\n')
+      ? (() => {
+          const sections = [
+            'Cargo orchestrates builds/tests; rustfmt formats code, and cargo-clippy provides linting. rustup manages toolchains.',
+          ];
+
+          if (installedTools.length > 0) {
+            sections.push('');
+            sections.push('### Tool availability');
+            sections.push(...installedTools.map((tool) => `- ${tool.summary}`));
+          }
+
+          return sections.join('\n');
+        })()
       : '';
 
     return createBootProbeResult({ detected, details, tooling });

--- a/src/cli/context.md
+++ b/src/cli/context.md
@@ -22,6 +22,7 @@
 - Command renderer surfaces the assistant-provided `description` line above command details so humans immediately see the intent.
 - ESC listener integrates with cancellation manager via `cancelActive('esc-key')`.
 - CLI modules now follow the repo-wide Prettier profile so lint parity across workflows prevents regressions.
+- Boot probe tooling summaries now only list installed CLI tools, keeping startup output focused on actionable utilities.
 
 ## Risks / Gaps
 

--- a/tests/unit/bootProbes.test.js
+++ b/tests/unit/bootProbes.test.js
@@ -239,7 +239,6 @@ describe('boot probes', () => {
         'python is installed and ready to use',
         'python3 is installed and ready to use',
         'pip is installed and ready to use',
-        'pip3 is not installed',
         'poetry is installed and ready to use',
         'pytest is installed and ready to use',
         'ruff is installed and ready to use',
@@ -247,7 +246,7 @@ describe('boot probes', () => {
     );
     expect(result.tooling).toContain('Tool availability');
     expect(result.tooling).toContain('- python is installed and ready to use');
-    expect(result.tooling).toContain('- pip3 is not installed');
+    expect(result.tooling).not.toContain('- pip3 is not installed');
   });
 
   it('summarises Go workspaces and tooling', async () => {
@@ -276,12 +275,14 @@ describe('boot probes', () => {
         'go.mod',
         'Go source files (main.go)',
         'cmd/ directory',
-        'goimports is not installed',
+        'go is installed and ready to use',
+        'gofmt is installed and ready to use',
         'golangci-lint is installed and ready to use',
       ])
     );
     expect(result.tooling).toContain('Go modules expect go build/test/vet');
     expect(result.tooling).toContain('- gofmt is installed and ready to use');
+    expect(result.tooling).not.toContain('- goimports is not installed');
   });
 
   it('summarises Rust workspaces and tooling', async () => {
@@ -312,12 +313,14 @@ describe('boot probes', () => {
         'src/ directory',
         'Rust sources (main.rs)',
         'Root Rust files (lib.rs)',
-        'rustfmt is not installed',
+        'cargo is installed and ready to use',
+        'rustc is installed and ready to use',
         'rustup is installed and ready to use',
       ])
     );
     expect(result.tooling).toContain('Cargo orchestrates builds/tests');
-    expect(result.tooling).toContain('- cargo-clippy is not installed');
+    expect(result.tooling).toContain('- cargo is installed and ready to use');
+    expect(result.tooling).not.toContain('- cargo-clippy is not installed');
   });
 
   it('summarises JVM build tooling and sources', async () => {
@@ -348,11 +351,13 @@ describe('boot probes', () => {
         'mvnw wrapper',
         'src/main/java (App.java)',
         'JVM sources (Main.kt)',
-        'maven (mvn) is not installed',
+        'java is installed and ready to use',
+        'javac is installed and ready to use',
       ])
     );
     expect(result.tooling).toContain('Use Maven or Gradle wrappers');
-    expect(result.tooling).toContain('- gradle is not installed');
+    expect(result.tooling).toContain('- java is installed and ready to use');
+    expect(result.tooling).not.toContain('- gradle is not installed');
   });
 
   it('summarises containerisation signals and tooling', async () => {
@@ -383,12 +388,13 @@ describe('boot probes', () => {
         'docker-compose.yml',
         '.devcontainer/devcontainer.json',
         '.devcontainer/ (devcontainer.json, Dockerfile)',
-        'docker-compose is not installed',
+        'docker is installed and ready to use',
         'nerdctl is installed and ready to use',
       ])
     );
     expect(result.tooling).toContain('Dockerfiles or devcontainers enable reproducible environments');
     expect(result.tooling).toContain('- docker is installed and ready to use');
+    expect(result.tooling).not.toContain('- docker-compose is not installed');
   });
 
   it('summarises Node.js tooling availability', async () => {
@@ -411,12 +417,12 @@ describe('boot probes', () => {
         'node is installed and ready to use',
         'npx is installed and ready to use',
         'npm is installed and ready to use',
-        'pnpm is not installed',
-        'yarn is not installed',
-        'bun is not installed',
       ])
     );
     expect(result.tooling).toContain('Tool availability');
     expect(result.tooling).toContain('- node is installed and ready to use');
+    expect(result.tooling).not.toContain('- pnpm is not installed');
+    expect(result.tooling).not.toContain('- yarn is not installed');
+    expect(result.tooling).not.toContain('- bun is not installed');
   });
 });


### PR DESCRIPTION
## Summary
- filter boot probe outputs so language/toolchain probes only list installed CLI utilities
- note the slimmer tooling output in the CLI context documentation
- update boot probe unit tests to reflect the installed-only availability details

## Testing
- npm test -- tests/unit/bootProbes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5583abb6083288bd281d3ae475efd