### PR TITLE
Hide boot probes for unrelated stacks

### DIFF
--- a/src/cli/context.md
+++ b/src/cli/context.md
@@ -23,6 +23,7 @@
 - ESC listener integrates with cancellation manager via `cancelActive('esc-key')`.
 - CLI modules now follow the repo-wide Prettier profile so lint parity across workflows prevents regressions.
 - Boot probe tooling summaries now only list installed CLI tools, keeping startup output focused on actionable utilities.
+- Boot probe output now hides probes that don't match the current workspace, keeping startup output focused on actionable utilities.
 
 ## Risks / Gaps
 


### PR DESCRIPTION
## Summary
- hide CLI boot probe output and summaries when a probe does not detect the current workspace
- require Node.js workspace indicators before surfacing Node tooling details and suppress tooling otherwise
- document the behavior change and extend boot probe unit tests for the filtered output

## Testing
- npm test -- bootProbes

------
https://chatgpt.com/codex/tasks/task_e_68e565e3d17c83288ea04e17cde03090