### PR TITLE
Handle continue refusal phrasing

### DIFF
--- a/src/agent/passExecutor.js
+++ b/src/agent/passExecutor.js
@@ -22,7 +22,11 @@ const REFUSAL_NEGATION_PATTERNS = [
   /\bwon['’]?t be able to\b/i,
 ];
 
-const REFUSAL_HELP_PATTERNS = [/\bhelp\b/i, /\bassist\b/i];
+const REFUSAL_ASSISTANCE_PATTERNS = [
+  /\bhelp\b/i,
+  /\bassist\b/i,
+  /\bcontinue\b/i, // e.g. "I can't continue with that."
+];
 
 const REFUSAL_SORRY_PATTERN = /\bsorry\b/i;
 
@@ -47,7 +51,7 @@ const isLikelyRefusalMessage = (message) => {
     return false;
   }
 
-  if (!REFUSAL_HELP_PATTERNS.some((pattern) => pattern.test(lowerCased))) {
+  if (!REFUSAL_ASSISTANCE_PATTERNS.some((pattern) => pattern.test(lowerCased))) {
     return false;
   }
 

--- a/tests/integration/agentLoop.integration.test.js
+++ b/tests/integration/agentLoop.integration.test.js
@@ -82,7 +82,11 @@ const driveRefusalAutoResponse = async (refusalMessage) => {
   return { mocks, ui };
 };
 
-test.each(['I’m sorry, but I can’t help with that.', "I'm sorry, I can't assist with that."])(
+test.each([
+  'I’m sorry, but I can’t help with that.',
+  "I'm sorry, I can't assist with that.",
+  'I’m sorry, but I can’t continue with that.',
+])(
   'auto-responds with continue when refusal looks like "%s"',
   async (refusalMessage) => {
     const { mocks, ui } = await driveRefusalAutoResponse(refusalMessage);


### PR DESCRIPTION
## Summary
- extend the refusal heuristic to catch "I can’t continue" style apologies
- update the integration test matrix to cover the new refusal message

## Testing
- npm test -- agentLoop.integration.test

------
https://chatgpt.com/codex/tasks/task_e_68e5d07650688328be01089c8828c85c