### PR TITLE
Fix Rust boot probe false positives for generic src directories

### DIFF
--- a/src/cli/bootProbes/rustProbe.js
+++ b/src/cli/bootProbes/rustProbe.js
@@ -36,19 +36,21 @@ export const RustBootProbe = {
     }
 
     for (const directory of RUST_DIRECTORIES) {
-      if (await context.fileExists(directory)) {
-        detected = true;
-        details.push(`${directory}/ directory`);
+      const entries = await context.readDirEntries(directory);
+      if (entries.length === 0) {
+        continue;
+      }
 
-        if (directory === 'src') {
-          const srcEntries = await context.readDirEntries('src');
-          const rustFiles = srcEntries.filter(
-            (entry) => entry.isFile?.() && /\.rs$/i.test(entry.name),
-          );
-          if (rustFiles.length > 0) {
-            details.push(`Rust sources (${formatExampleEntries(rustFiles)})`);
-          }
-        }
+      const rustFiles = entries.filter((entry) => entry.isFile?.() && /\.rs$/i.test(entry.name));
+      if (rustFiles.length === 0) {
+        continue;
+      }
+
+      detected = true;
+      details.push(`${directory}/ directory`);
+
+      if (directory === 'src') {
+        details.push(`Rust sources (${formatExampleEntries(rustFiles)})`);
       }
     }
 

--- a/src/cli/context.md
+++ b/src/cli/context.md
@@ -22,6 +22,7 @@
 - CLI modules now follow the repo-wide Prettier profile so lint parity across workflows prevents regressions.
 - Boot probe tooling summaries now only list installed CLI tools, keeping startup output focused on actionable utilities.
 - Boot probe output now hides probes that don't match the current workspace, keeping startup output focused on actionable utilities.
+- Rust boot probe now confirms Rust source files exist before marking the workspace as detected, preventing false positives in JavaScript projects with similarly named directories.
 
 ## Risks / Gaps
 

--- a/tests/unit/bootProbes.test.js
+++ b/tests/unit/bootProbes.test.js
@@ -173,6 +173,18 @@ describe('boot probes', () => {
     });
   });
 
+  it('does not report Rust when only generic directories are present', async () => {
+    await withTempDir(async (dir) => {
+      await mkdir(join(dir, 'src'), { recursive: true });
+      await writeFile(join(dir, 'src', 'index.js'), 'console.log("hello");\n', 'utf8');
+
+      const results = await runBootProbes({ cwd: dir, emit: () => {} });
+      const rustResult = results.find((result) => result.probe === 'Rust');
+
+      expect(rustResult).toBeUndefined();
+    });
+  });
+
   it('detects ESLint configuration from package.json and config files', async () => {
     await withTempDir(async (dir) => {
       await writeFile(


### PR DESCRIPTION
## Summary
- tighten the Rust boot probe so it only detects directories that contain Rust source files
- add a regression test to ensure generic `src` folders no longer trigger the Rust probe
- update the CLI context documentation to reflect the improved Rust detection heuristic

## Testing
- npm test -- bootProbes

------
https://chatgpt.com/codex/tasks/task_e_68e5e2ac6ce0832887f7c58c556182b2