### PR TITLE
feat: redesign CLI with Ink components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,13 @@
         "chalk": "^4.1.2",
         "diff": "^8.0.2",
         "dotenv": "^17.2.3",
+        "ink": "^6.3.1",
+        "ink-spinner": "^5.0.0",
         "inquirer": "^12.9.6",
         "marked": "^12.0.2",
         "marked-terminal": "^7.1.0",
-        "openai": "^6.1.0"
+        "openai": "^6.1.0",
+        "react": "^19.2.0"
       },
       "bin": {
         "openagent": "bin/openagent.js"
@@ -33,6 +36,46 @@
         "jest": "^29.7.0",
         "lint-staged": "^16.2.3",
         "prettier": "^3.2.5"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.0.tgz",
+      "integrity": "sha512-qI/5TaaaCZE4yeSZ83lu0+xi1r88JSxUjnH4OP/iZF7+KKZ75u3ee5isd0LxX+6N8U0npL61YrpbthILHB6BnA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1947,6 +1990,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2331,6 +2386,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -2366,6 +2433,18 @@
       "engines": {
         "node": ">=8.0.0",
         "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-table3": {
@@ -2464,6 +2543,18 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -2519,6 +2610,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2969,6 +3069,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.39.10",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2982,7 +3092,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3745,7 +3854,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
       "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4128,6 +4236,18 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4146,6 +4266,235 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ink": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.3.1.tgz",
+      "integrity": "sha512-3wGwITGrzL6rkWsi2gEKzgwdafGn4ZYd3u4oRp+sOPvfoxEHlnoB5Vnk9Uy5dMRUhDOqF3hqr4rLQ4lEzBc2sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.2.0",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.39.10",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.32.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.0.0",
+        "react": ">=19.0.0",
+        "react-devtools-core": "^6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-spinner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "ink": ">=4.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/ink/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/inquirer": {
       "version": "12.9.6",
@@ -4406,6 +4755,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-map": {
@@ -5865,7 +6229,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6126,7 +6489,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -6302,6 +6664,15 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "license": "MIT"
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -6522,12 +6893,36 @@
       ],
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.32.0.tgz",
+      "integrity": "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -6830,6 +7225,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -6992,7 +7393,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -7028,7 +7428,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
       "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -7045,7 +7444,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7058,7 +7456,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.3.1"
@@ -7102,7 +7499,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -7758,6 +8154,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7819,6 +8268,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {
@@ -7901,6 +8371,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,13 @@
     "chalk": "^4.1.2",
     "diff": "^8.0.2",
     "dotenv": "^17.2.3",
+    "ink": "^6.3.1",
+    "ink-spinner": "^5.0.0",
     "inquirer": "^12.9.6",
     "marked": "^12.0.2",
     "marked-terminal": "^7.1.0",
-    "openai": "^6.1.0"
+    "openai": "^6.1.0",
+    "react": "^19.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.37.0",

--- a/src/cli/components/AgentResponse.js
+++ b/src/cli/components/AgentResponse.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+import { renderMarkdownMessage, wrapStructuredContent } from '../render.js';
+
+const h = React.createElement;
+
+/**
+ * Renders assistant messages using Ink so Markdown formatting carries through to
+ * the terminal UI.
+ */
+export function AgentResponse({ message }) {
+  const prepared = wrapStructuredContent(message);
+
+  if (!prepared) {
+    return null;
+  }
+
+  const rendered = renderMarkdownMessage(prepared);
+
+  return h(
+    Box,
+    { flexDirection: 'column', marginTop: 1 },
+    [
+      h(Text, { color: 'magentaBright', bold: true, key: 'heading' }, 'Assistant'),
+      h(Box, { marginLeft: 2, key: 'body' }, h(Text, null, rendered)),
+    ],
+  );
+}
+
+export default AgentResponse;

--- a/src/cli/components/AskHuman.js
+++ b/src/cli/components/AskHuman.js
@@ -1,0 +1,71 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+const h = React.createElement;
+
+/**
+ * Collects free-form user input while keeping the prompt visible inside the Ink
+ * layout.
+ */
+export function AskHuman({ prompt = '▷', onSubmit }) {
+  const [value, setValue] = useState('');
+  const [locked, setLocked] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => () => {
+    mountedRef.current = false;
+  }, []);
+
+  const normalizedPrompt = useMemo(() => {
+    if (typeof prompt !== 'string') {
+      return '▷';
+    }
+    const trimmed = prompt.trim();
+    return trimmed.length > 0 ? trimmed : '▷';
+  }, [prompt]);
+
+  useInput(
+    (input, key) => {
+      if (locked) {
+        return;
+      }
+      if (key.return) {
+        const submission = value.trim();
+        setLocked(true);
+        Promise.resolve()
+          .then(() => onSubmit?.(submission))
+          .finally(() => {
+            if (!mountedRef.current) {
+              return;
+            }
+            setValue('');
+            setLocked(false);
+          });
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setValue((prev) => prev.slice(0, -1));
+        return;
+      }
+      if (key.ctrl || key.meta) {
+        return;
+      }
+      if (input) {
+        setValue((prev) => prev + input);
+      }
+    },
+    { isActive: true },
+  );
+
+  return h(
+    Box,
+    { flexDirection: 'column', marginTop: 1 },
+    [
+      h(Text, { color: 'blueBright', bold: true, key: 'prompt' }, normalizedPrompt),
+      h(Text, { key: 'value' }, value || ' '),
+      h(Text, { dimColor: true, key: 'hint' }, 'Press Enter to submit • Esc to cancel'),
+    ],
+  );
+}
+
+export default AskHuman;

--- a/src/cli/components/CliApp.js
+++ b/src/cli/components/CliApp.js
@@ -1,0 +1,327 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Text, useApp, useInput } from 'ink';
+
+import { cancel as cancelActive } from '../../utils/cancellation.js';
+import AgentResponse from './AgentResponse.js';
+import AskHuman from './AskHuman.js';
+import Command from './Command.js';
+import Plan from './Plan.js';
+import PlanProgress from './PlanProgress.js';
+import DebugPanel from './DebugPanel.js';
+import StatusMessage from './StatusMessage.js';
+import ContextUsage from './ContextUsage.js';
+import ThinkingIndicator from './ThinkingIndicator.js';
+
+const MAX_TIMELINE_ENTRIES = 100;
+const MAX_DEBUG_ENTRIES = 20;
+
+const h = React.createElement;
+
+function formatDebugPayload(payload) {
+  if (typeof payload === 'string') {
+    return payload;
+  }
+  try {
+    return JSON.stringify(payload, null, 2);
+  } catch (error) {
+    return String(payload);
+  }
+}
+
+function normalizeStatus(event) {
+  const message = event.message ?? '';
+  if (!message) {
+    return null;
+  }
+  const normalized = {
+    level: event.level ?? 'info',
+    message,
+  };
+  if (event.details !== undefined && event.details !== null) {
+    normalized.details = String(event.details);
+  }
+  return normalized;
+}
+
+/**
+ * Main Ink container responsible for driving the CLI experience.
+ */
+export function CliApp({ runtime, onRuntimeComplete, onRuntimeError }) {
+  const runtimeRef = useRef(runtime);
+  const { exit } = useApp();
+  const entryIdRef = useRef(0);
+  const [banner, setBanner] = useState(null);
+  const [plan, setPlan] = useState([]);
+  const [planProgress, setPlanProgress] = useState({ seen: false, value: null });
+  const [contextUsage, setContextUsage] = useState(null);
+  const [thinking, setThinking] = useState(false);
+  const [inputRequest, setInputRequest] = useState(null);
+  const [entries, setEntries] = useState([]);
+  const [debugEvents, setDebugEvents] = useState([]);
+  const [exitState, setExitState] = useState(null);
+
+  const appendEntry = useCallback((type, payload) => {
+    entryIdRef.current += 1;
+    const id = entryIdRef.current;
+    setEntries((prev) => {
+      const next = [...prev, { id, type, payload }];
+      if (next.length > MAX_TIMELINE_ENTRIES) {
+        return next.slice(next.length - MAX_TIMELINE_ENTRIES);
+      }
+      return next;
+    });
+  }, []);
+
+  const safeSetExitState = useCallback((next) => {
+    setExitState((prev) => prev ?? next);
+  }, []);
+
+  const handleCommandEvent = useCallback(
+    (event) => {
+      appendEntry('command-result', {
+        command: event.command,
+        result: event.result,
+        preview: event.preview || {},
+        execution: event.execution,
+      });
+    },
+    [appendEntry],
+  );
+
+  const handleAssistantMessage = useCallback(
+    (event) => {
+      appendEntry('assistant-message', { message: event.message ?? '' });
+    },
+    [appendEntry],
+  );
+
+  const handleStatusEvent = useCallback(
+    (event) => {
+      const status = normalizeStatus(event);
+      if (!status) {
+        return;
+      }
+      appendEntry('status', status);
+    },
+    [appendEntry],
+  );
+
+  const handleDebugEvent = useCallback((event) => {
+    setDebugEvents((prev) => {
+      const formatted = formatDebugPayload(event.payload);
+      if (!formatted) {
+        return prev;
+      }
+      const next = [...prev, formatted];
+      if (next.length > MAX_DEBUG_ENTRIES) {
+        return next.slice(next.length - MAX_DEBUG_ENTRIES);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSubmitPrompt = useCallback(
+    (value) => {
+      try {
+        runtimeRef.current?.submitPrompt?.(value);
+      } catch (error) {
+        handleStatusEvent({ level: 'error', message: 'Failed to submit input.', details: error });
+      }
+      setInputRequest(null);
+    },
+    [handleStatusEvent],
+  );
+
+  const handleEvent = useCallback(
+    (event) => {
+      if (!event || typeof event !== 'object') {
+        return;
+      }
+
+      switch (event.type) {
+        case 'banner':
+          setBanner({ title: event.title, subtitle: event.subtitle });
+          break;
+        case 'status':
+          handleStatusEvent(event);
+          break;
+        case 'thinking':
+          setThinking(event.state === 'start');
+          break;
+        case 'assistant-message':
+          handleAssistantMessage(event);
+          break;
+        case 'plan':
+          setPlan(Array.isArray(event.plan) ? event.plan : []);
+          break;
+        case 'plan-progress':
+          setPlanProgress({ seen: true, value: event.progress || null });
+          break;
+        case 'context-usage':
+          setContextUsage(event.usage || null);
+          break;
+        case 'command-result':
+          handleCommandEvent(event);
+          break;
+        case 'error':
+          handleStatusEvent({
+            level: 'error',
+            message: event.message || 'Agent error encountered.',
+            details: event.details || event.raw,
+          });
+          break;
+        case 'request-input':
+          setInputRequest({ prompt: event.prompt ?? '▷', metadata: event.metadata || null });
+          break;
+        case 'debug':
+          handleDebugEvent(event);
+          break;
+        default:
+          break;
+      }
+    },
+    [handleAssistantMessage, handleCommandEvent, handleDebugEvent, handleStatusEvent],
+  );
+
+  useEffect(() => {
+    const activeRuntime = runtimeRef.current;
+    if (!activeRuntime) {
+      return undefined;
+    }
+
+    let canceled = false;
+    const startPromise = activeRuntime.start();
+
+    (async () => {
+      try {
+        for await (const event of activeRuntime.outputs) {
+          if (canceled) {
+            break;
+          }
+          handleEvent(event);
+        }
+        await startPromise;
+        if (!canceled) {
+          safeSetExitState({ status: 'success' });
+        }
+      } catch (error) {
+        if (!canceled) {
+          safeSetExitState({ status: 'error', error });
+        }
+      }
+    })();
+
+    startPromise.catch((error) => {
+      if (!canceled) {
+        safeSetExitState({ status: 'error', error });
+      }
+    });
+
+    return () => {
+      canceled = true;
+      try {
+        activeRuntime.cancel?.({ reason: 'component-unmount' });
+      } catch (error) {
+        // Ignore cancellation failures.
+      }
+    };
+  }, [handleEvent, safeSetExitState]);
+
+  useEffect(() => {
+    if (!exitState) {
+      return;
+    }
+
+    if (exitState.status === 'error') {
+      onRuntimeError?.(exitState.error);
+    } else {
+      onRuntimeComplete?.();
+    }
+
+    exit();
+  }, [exit, exitState, onRuntimeComplete, onRuntimeError]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      cancelActive('esc-key');
+      runtimeRef.current?.cancel?.({ reason: 'escape-key' });
+      return;
+    }
+    if (key.ctrl && (key.name === 'c' || input === 'c')) {
+      runtimeRef.current?.cancel?.({ reason: 'ctrl-c' });
+      safeSetExitState({ status: 'success' });
+    }
+  });
+
+  const hasDebugEvents = debugEvents.length > 0;
+  const renderedBanner = useMemo(() => {
+    if (!banner) {
+      return null;
+    }
+    const elements = [];
+    if (banner.title) {
+      elements.push(h(Text, { color: 'blueBright', bold: true, key: 'title' }, banner.title));
+    }
+    if (banner.subtitle) {
+      elements.push(h(Text, { dimColor: true, key: 'subtitle' }, banner.subtitle));
+    }
+    return h(Box, { flexDirection: 'column', marginBottom: 1 }, elements);
+  }, [banner]);
+
+  const children = [];
+  if (renderedBanner) {
+    children.push(renderedBanner);
+  }
+
+  children.push(h(Plan, { plan, key: 'plan' }));
+  if (planProgress.seen) {
+    children.push(h(PlanProgress, { progress: planProgress.value, key: 'plan-progress' }));
+  }
+  if (contextUsage) {
+    children.push(h(ContextUsage, { usage: contextUsage, key: 'context-usage' }));
+  }
+
+  entries.forEach((entry) => {
+    switch (entry.type) {
+      case 'assistant-message':
+        children.push(h(AgentResponse, { key: entry.id, message: entry.payload.message }));
+        break;
+      case 'command-result':
+        children.push(
+          h(Command, {
+            key: entry.id,
+            command: entry.payload.command,
+            result: entry.payload.result,
+            preview: entry.payload.preview,
+            execution: entry.payload.execution,
+          }),
+        );
+        break;
+      case 'status':
+        children.push(h(StatusMessage, { key: entry.id, status: entry.payload }));
+        break;
+      default:
+        break;
+    }
+  });
+
+  if (hasDebugEvents) {
+    children.push(h(DebugPanel, { events: debugEvents, key: 'debug' }));
+  }
+
+  children.push(h(ThinkingIndicator, { active: thinking, key: 'thinking' }));
+
+  if (inputRequest) {
+    children.push(
+      h(AskHuman, {
+        prompt: inputRequest.prompt,
+        onSubmit: handleSubmitPrompt,
+        key: 'ask-human',
+      }),
+    );
+  }
+
+  return h(Box, { flexDirection: 'column' }, children);
+}
+
+export default CliApp;

--- a/src/cli/components/Command.js
+++ b/src/cli/components/Command.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+import { buildCommandRenderData } from './commandUtils.js';
+
+const h = React.createElement;
+
+function SummaryLine({ line, index }) {
+  switch (line.kind) {
+    case 'error-arrow':
+      return h(Text, { key: index, color: 'red' }, `└ ${line.text}`);
+    case 'error-indent':
+      return h(Text, { key: index, color: 'red' }, `   ${line.text}`);
+    case 'indent':
+      return h(Text, { key: index, dimColor: true }, `   ${line.text}`);
+    case 'exit-code':
+      return h(Text, { key: index, color: line.status === 'success' ? 'green' : 'red' }, `   ${line.text}`);
+    case 'arrow':
+    default:
+      return h(Text, { key: index, dimColor: true }, `└ ${line.text}`);
+  }
+}
+
+/**
+ * Displays command execution details, mirroring the textual summaries.
+ */
+export function Command({ command, result, preview = {}, execution = {} }) {
+  const data = buildCommandRenderData(command, result, preview, execution);
+
+  if (!data) {
+    return null;
+  }
+
+  const { type, detail, description, summaryLines } = data;
+  const children = [];
+
+  if (description) {
+    children.push(
+      h(
+        Text,
+        { key: 'description' },
+        h(Text, { color: 'blueBright', bold: true }, 'DESCRIPTION'),
+        h(Text, null, ` ${description}`),
+      ),
+    );
+  }
+
+  children.push(
+    h(
+      Text,
+      { key: 'heading' },
+      h(Text, { color: 'blueBright', bold: true }, type),
+      h(Text, null, ` ${detail}`),
+    ),
+  );
+
+  summaryLines.forEach((line, index) => {
+    children.push(h(SummaryLine, { line, index, key: `summary-${index}` }));
+  });
+
+  return h(Box, { flexDirection: 'column', marginTop: 1 }, children);
+}
+
+export default Command;

--- a/src/cli/components/ContextUsage.js
+++ b/src/cli/components/ContextUsage.js
@@ -1,0 +1,62 @@
+import React, { useMemo } from 'react';
+import { Text } from 'ink';
+
+const h = React.createElement;
+
+function formatPercentage(value) {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  if (value >= 10) {
+    return value.toFixed(0);
+  }
+  return value.toFixed(1);
+}
+
+/**
+ * Mirrors the legacy context usage status line.
+ */
+export function ContextUsage({ usage }) {
+  const line = useMemo(() => {
+    if (!usage || typeof usage !== 'object') {
+      return '';
+    }
+
+    const { total, used, remaining, percentRemaining } = usage;
+
+    if (!Number.isFinite(total) || total <= 0) {
+      return '';
+    }
+
+    const safeRemaining = Number.isFinite(remaining) ? Math.max(remaining, 0) : null;
+    const safeUsed = Number.isFinite(used) ? Math.max(used, 0) : null;
+    const percent = Number.isFinite(percentRemaining)
+      ? Math.max(Math.min(percentRemaining, 100), 0)
+      : safeRemaining !== null
+        ? (safeRemaining / total) * 100
+        : null;
+
+    const parts = [`Context remaining: ${safeRemaining?.toLocaleString?.() ?? '—'} / ${total.toLocaleString?.() ?? total}`];
+
+    if (percent !== null) {
+      const formatted = formatPercentage(percent);
+      if (formatted !== null) {
+        parts.push(`(${formatted}% left)`);
+      }
+    }
+
+    if (safeUsed !== null) {
+      parts.push(`• used ≈ ${safeUsed.toLocaleString?.() ?? safeUsed}`);
+    }
+
+    return parts.join(' ');
+  }, [usage]);
+
+  if (!line) {
+    return null;
+  }
+
+  return h(Text, { dimColor: true }, line);
+}
+
+export default ContextUsage;

--- a/src/cli/components/DebugPanel.js
+++ b/src/cli/components/DebugPanel.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+const h = React.createElement;
+
+/**
+ * Displays debug payloads emitted by the agent when the debug flag is active.
+ */
+export function DebugPanel({ events = [] }) {
+  if (!Array.isArray(events) || events.length === 0) {
+    return null;
+  }
+
+  const children = [h(Text, { color: 'gray', bold: true, key: 'heading' }, 'Debug')];
+  events.forEach((event, index) => {
+    children.push(h(Text, { color: 'gray', key: `debug-${index}` }, event));
+  });
+
+  return h(Box, { flexDirection: 'column', marginTop: 1 }, children);
+}
+
+export default DebugPanel;

--- a/src/cli/components/Plan.js
+++ b/src/cli/components/Plan.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+import { createPlanNodes } from './planUtils.js';
+import PlanDetail from './PlanDetail.js';
+
+const h = React.createElement;
+
+/**
+ * High-level plan renderer that lists every step using `PlanDetail` rows.
+ */
+export function Plan({ plan }) {
+  const nodes = createPlanNodes(plan);
+
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  const children = [h(Text, { color: 'blueBright', bold: true, key: 'heading' }, 'Plan')];
+  for (const node of nodes) {
+    children.push(h(PlanDetail, { key: node.id, node }));
+  }
+
+  return h(Box, { flexDirection: 'column', marginTop: 1 }, children);
+}
+
+export default Plan;

--- a/src/cli/components/PlanDetail.js
+++ b/src/cli/components/PlanDetail.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+const h = React.createElement;
+
+/**
+ * Displays a single plan entry with indentation that mirrors the hierarchy.
+ */
+export function PlanDetail({ node }) {
+  if (!node) {
+    return null;
+  }
+
+  return h(
+    Box,
+    { marginLeft: node.depth * 2 },
+    h(
+      Text,
+      null,
+      h(Text, { color: node.color }, `${node.symbol} `),
+      h(Text, { color: 'cyan' }, node.label),
+      h(Text, { color: 'gray' }, '.'),
+      node.title ? h(Text, null, ` ${node.title}`) : null,
+    ),
+  );
+}
+
+export default PlanDetail;

--- a/src/cli/components/PlanProgress.js
+++ b/src/cli/components/PlanProgress.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+import { computeProgressState } from './progressUtils.js';
+
+const h = React.createElement;
+
+/**
+ * Compact progress bar that mirrors the text-based renderer but using Ink.
+ */
+export function PlanProgress({ progress }) {
+  const state = computeProgressState(progress);
+
+  if (state.total <= 0) {
+    return h(
+      Box,
+      { marginTop: 1 },
+      [
+        h(Text, { color: 'blueBright', key: 'label' }, 'Plan progress: '),
+        h(Text, { dimColor: true, key: 'empty' }, 'no active steps yet.'),
+      ],
+    );
+  }
+
+  const filledBar = state.filled > 0 ? '█'.repeat(state.filled) : '';
+  const emptyBar = state.empty > 0 ? '░'.repeat(state.empty) : '';
+  const percentLabel = `${Math.round(state.normalized * 100)}%`;
+  const summary = `${state.completed}/${state.total}`;
+
+  return h(
+    Box,
+    { marginTop: 1 },
+    [
+      h(Text, { color: 'blueBright', key: 'label' }, 'Plan progress: '),
+      h(Text, { color: 'green', key: 'filled' }, filledBar),
+      h(Text, { color: 'gray', key: 'empty' }, emptyBar),
+      h(Text, { key: 'space' }, ' '),
+      h(Text, { bold: true, key: 'percent' }, percentLabel),
+      h(Text, { key: 'summary' }, ` (${summary})`),
+    ],
+  );
+}
+
+export default PlanProgress;

--- a/src/cli/components/StatusMessage.js
+++ b/src/cli/components/StatusMessage.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+const h = React.createElement;
+
+function resolveColor(level) {
+  switch (level) {
+    case 'warn':
+      return 'yellow';
+    case 'error':
+      return 'red';
+    case 'success':
+      return 'green';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Lightweight status line renderer that mirrors the legacy console output.
+ */
+export function StatusMessage({ status }) {
+  if (!status || typeof status !== 'object') {
+    return null;
+  }
+
+  const color = resolveColor(status.level);
+  const message = status.message ?? '';
+  const details = status.details ? String(status.details) : '';
+
+  const children = [h(Text, { color }, message)];
+  if (details) {
+    children.push(h(Text, { dimColor: true }, details));
+  }
+
+  return h(Box, { flexDirection: 'column' }, children);
+}
+
+export default StatusMessage;

--- a/src/cli/components/ThinkingIndicator.js
+++ b/src/cli/components/ThinkingIndicator.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
+
+const h = React.createElement;
+
+/**
+ * Spinner shown while the agent waits on the model or command execution.
+ */
+export function ThinkingIndicator({ active }) {
+  if (!active) {
+    return null;
+  }
+
+  return h(
+    Box,
+    { marginTop: 1 },
+    h(Text, { dimColor: true }, [h(Spinner, { type: 'dots', key: 'spinner' }), ' Thinking…']),
+  );
+}
+
+export default ThinkingIndicator;

--- a/src/cli/components/commandUtils.js
+++ b/src/cli/components/commandUtils.js
@@ -1,0 +1,314 @@
+/**
+ * Shared formatting helpers for command summaries across Ink components and
+ * compatibility console renderers.
+ */
+
+export function normalizePreviewLines(preview) {
+  if (!preview) {
+    return [];
+  }
+  const lines = String(preview).split('\n');
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+  return lines;
+}
+
+export function collectReadPaths(spec) {
+  const paths = [];
+  if (!spec || typeof spec !== 'object') {
+    return paths;
+  }
+
+  const addPath = (candidate) => {
+    if (typeof candidate !== 'string') {
+      return;
+    }
+    const trimmed = candidate.trim();
+    if (!trimmed || paths.includes(trimmed)) {
+      return;
+    }
+    paths.push(trimmed);
+  };
+
+  addPath(spec.path);
+  if (Array.isArray(spec.paths)) {
+    for (const candidate of spec.paths) {
+      addPath(candidate);
+    }
+  }
+
+  return paths;
+}
+
+export function parseReadSegments(stdout) {
+  if (!stdout) {
+    return [];
+  }
+
+  const lines = String(stdout).split('\n');
+  const segments = [];
+  let current = null;
+
+  for (const line of lines) {
+    if (line.endsWith(':::')) {
+      if (current) {
+        const { path, content } = current;
+        while (content.length > 0 && content[content.length - 1] === '') {
+          content.pop();
+        }
+        segments.push({ path, lineCount: content.length });
+      }
+      current = { path: line.slice(0, -3), content: [] };
+    } else if (current) {
+      current.content.push(line);
+    }
+  }
+
+  if (current) {
+    const { path, content } = current;
+    while (content.length > 0 && content[content.length - 1] === '') {
+      content.pop();
+    }
+    segments.push({ path, lineCount: content.length });
+  }
+
+  return segments;
+}
+
+export function inferCommandType(command, execution) {
+  if (!command || typeof command !== 'object') {
+    return 'EXECUTE';
+  }
+
+  if (execution?.type) {
+    return String(execution.type).toUpperCase();
+  }
+
+  if (command.edit) return 'EDIT';
+  if (command.read) return 'READ';
+  if (command.replace) return 'REPLACE';
+
+  const runValue = typeof command.run === 'string' ? command.run.trim() : '';
+  if (runValue) {
+    const keyword = runValue.split(/\s+/)[0]?.toLowerCase();
+    if (keyword === 'read') {
+      return 'READ';
+    }
+  }
+
+  return 'EXECUTE';
+}
+
+function pluralize(word, count) {
+  return `${word}${count === 1 ? '' : 's'}`;
+}
+
+export function buildHeadingDetail(type, execution, command) {
+  switch (type) {
+    case 'READ': {
+      const spec = execution?.spec || command?.read || {};
+      const paths = collectReadPaths(spec);
+      return `([${paths.join(', ')}])`;
+    }
+    case 'EDIT': {
+      const spec = execution?.spec || command?.edit || {};
+      const parts = [];
+      if (spec.path) {
+        parts.push(spec.path);
+      }
+      if (spec.encoding) {
+        parts.push(spec.encoding);
+      }
+      const editCount = Array.isArray(spec.edits) ? spec.edits.length : 0;
+      parts.push(`${editCount} ${pluralize('edit', editCount)}`);
+      return `(${parts.join(', ')})`;
+    }
+    case 'REPLACE': {
+      const spec = execution?.spec || command?.replace || {};
+      const parts = [];
+      if (spec.pattern !== undefined) {
+        parts.push(`pattern: ${JSON.stringify(spec.pattern ?? '')}`);
+      }
+      if (spec.replacement !== undefined) {
+        parts.push(`replacement: ${JSON.stringify(spec.replacement ?? '')}`);
+      }
+      const files = Array.isArray(spec.files) ? spec.files.filter(Boolean) : [];
+      if (files.length > 0) {
+        parts.push(`[${files.join(', ')}]`);
+      }
+      if (spec.dry_run || spec.dryRun) {
+        parts.push('dry-run');
+      }
+      return `(${parts.join(', ')})`;
+    }
+    default: {
+      const runValue =
+        (execution?.command && typeof execution.command.run === 'string'
+          ? execution.command.run
+          : typeof command?.run === 'string'
+            ? command.run
+            : '') || '';
+      const trimmed = runValue.trim();
+      return `(${trimmed || 'shell command'})`;
+    }
+  }
+}
+
+export function extractCommandDescription(command, execution) {
+  const candidates = [command?.description, execution?.command?.description, execution?.description];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+
+  return '';
+}
+
+function appendStdErr(summaryLines, stderrPreview) {
+  const stderrLines = normalizePreviewLines(stderrPreview);
+  if (stderrLines.length === 0) {
+    return;
+  }
+
+  summaryLines.push({ kind: 'error-arrow', text: `STDERR: ${stderrLines[0]}` });
+  for (const line of stderrLines.slice(1)) {
+    summaryLines.push({ kind: 'error-indent', text: line });
+  }
+}
+
+function summarizeReadCommand({ command, result, preview, execution, summaryLines }) {
+  const filtersApplied = Boolean(command?.filter_regex || command?.tail_lines);
+  const spec = execution?.spec || command?.read || {};
+  const paths = collectReadPaths(spec);
+
+  let segments = parseReadSegments(preview.stdout);
+  if (segments.length === 0 && !filtersApplied && result?.stdout) {
+    const fallbackSegments = parseReadSegments(result.stdout);
+    if (fallbackSegments.length > 0) {
+      segments = fallbackSegments;
+    }
+  }
+
+  if (segments.length > 0) {
+    const totalLines = segments.reduce((acc, item) => acc + item.lineCount, 0);
+    summaryLines.push({
+      kind: 'arrow',
+      text: `Read ${totalLines} ${pluralize('line', totalLines)} from ${segments.length} ${pluralize('file', segments.length)}.`,
+    });
+    for (const segment of segments) {
+      const label = segment.path || '(unknown path)';
+      summaryLines.push({
+        kind: 'indent',
+        text: `${label}: ${segment.lineCount} ${pluralize('line', segment.lineCount)}`,
+      });
+    }
+  } else if (paths.length > 0) {
+    const fileCount = paths.length;
+    const baseMessage = filtersApplied
+      ? `No lines matched the applied filters across ${fileCount} ${pluralize('file', fileCount)}.`
+      : `Read 0 lines from ${fileCount} ${pluralize('file', fileCount)}.`;
+    summaryLines.push({ kind: 'arrow', text: baseMessage });
+    for (const label of paths) {
+      summaryLines.push({ kind: 'indent', text: `${label}: 0 lines` });
+    }
+  }
+}
+
+function summarizeEditOrReplace({ preview, summaryLines }) {
+  const stdoutLines = normalizePreviewLines(preview.stdoutPreview);
+  if (stdoutLines.length === 0) {
+    return;
+  }
+  summaryLines.push({ kind: 'arrow', text: stdoutLines[0] });
+  for (const line of stdoutLines.slice(1)) {
+    summaryLines.push({ kind: 'indent', text: line });
+  }
+}
+
+function summarizeExecute({ preview, summaryLines }) {
+  const stdoutLines = normalizePreviewLines(preview.stdoutPreview);
+  if (stdoutLines.length === 0) {
+    return;
+  }
+  summaryLines.push({ kind: 'arrow', text: stdoutLines[0] });
+  if (stdoutLines.length > 2) {
+    const middleCount = stdoutLines.length - 2;
+    summaryLines.push({
+      kind: 'indent',
+      text: `+ ${middleCount} more ${pluralize('line', middleCount)}`,
+    });
+  }
+  if (stdoutLines.length > 1) {
+    summaryLines.push({ kind: 'indent', text: stdoutLines[stdoutLines.length - 1] });
+  }
+}
+
+export function buildCommandRenderData(command, result, preview = {}, execution = {}) {
+  if (!command || typeof command !== 'object') {
+    return null;
+  }
+
+  const normalizedExecution = execution && typeof execution === 'object' ? execution : preview.execution || {};
+  const type = inferCommandType(command, normalizedExecution).toUpperCase();
+  const detail = buildHeadingDetail(type, normalizedExecution, command);
+  const description = extractCommandDescription(command, normalizedExecution);
+  const summaryLines = [];
+
+  const summaryContext = { command, result, preview, execution: normalizedExecution, summaryLines };
+
+  if (type === 'READ') {
+    summarizeReadCommand(summaryContext);
+  } else if (type === 'EDIT' || type === 'REPLACE') {
+    summarizeEditOrReplace(summaryContext);
+  } else {
+    summarizeExecute(summaryContext);
+  }
+
+  if (summaryLines.length === 0 && result?.exit_code === 0 && !preview.stderrPreview) {
+    summaryLines.push({ kind: 'arrow', text: 'Command completed successfully.' });
+  }
+
+  if (preview.stderrPreview) {
+    appendStdErr(summaryLines, preview.stderrPreview);
+  }
+
+  if (result) {
+    if (typeof result.exit_code === 'number') {
+      summaryLines.push({
+        kind: 'exit-code',
+        text: `Exit code: ${result.exit_code}`,
+        status: result.exit_code === 0 ? 'success' : 'error',
+      });
+    }
+    if (result.killed) {
+      summaryLines.push({ kind: 'indent', text: 'Process terminated (timeout).' });
+    }
+  }
+
+  if (summaryLines.length === 0) {
+    summaryLines.push({ kind: 'arrow', text: 'No output.' });
+  }
+
+  return {
+    type,
+    detail,
+    description,
+    summaryLines,
+  };
+}
+
+export default {
+  normalizePreviewLines,
+  collectReadPaths,
+  parseReadSegments,
+  inferCommandType,
+  buildHeadingDetail,
+  extractCommandDescription,
+  buildCommandRenderData,
+};

--- a/src/cli/components/planUtils.js
+++ b/src/cli/components/planUtils.js
@@ -1,0 +1,97 @@
+/**
+ * Helpers for transforming agent plans into renderable structures shared between
+ * the Ink components and the legacy console helpers.
+ */
+
+const CHILD_KEYS = ['substeps', 'children', 'steps'];
+
+function resolveStatusDetails(status) {
+  const normalized = typeof status === 'string' ? status.toLowerCase() : '';
+
+  if (normalized === 'completed' || normalized === 'done') {
+    return { symbol: '✔', color: 'green' };
+  }
+
+  if (normalized === 'running' || normalized === 'in_progress' || normalized === 'in-progress') {
+    return { symbol: '▶', color: 'yellow' };
+  }
+
+  if (normalized === 'blocked' || normalized === 'failed' || normalized === 'error') {
+    return { symbol: '✖', color: 'red' };
+  }
+
+  return { symbol: '•', color: 'gray' };
+}
+
+function sanitizeStepValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim().replace(/\.+$/, '');
+}
+
+function buildLabelParts(rawStep, index, ancestors) {
+  const sanitized = sanitizeStepValue(rawStep);
+  const hasExplicitStep = sanitized.length > 0;
+  const baseStep = hasExplicitStep ? sanitized : String(index + 1);
+  const usesAbsolutePath = hasExplicitStep && sanitized.includes('.');
+  const labelParts = usesAbsolutePath
+    ? sanitized
+        .split('.')
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0)
+    : [...ancestors, baseStep];
+
+  return { label: labelParts.join('.'), labelParts };
+}
+
+function traversePlan(items, ancestors = [], depth = 0, collection = []) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return collection;
+  }
+
+  items.forEach((item, index) => {
+    if (!item || typeof item !== 'object') {
+      return;
+    }
+
+    const { label, labelParts } = buildLabelParts(item.step, index, ancestors);
+    const { symbol, color } = resolveStatusDetails(item.status);
+    const title = item.title !== undefined && item.title !== null ? String(item.title) : '';
+    const id = `${label || depth}-${index}-${depth}`;
+
+    collection.push({
+      id,
+      label,
+      depth,
+      symbol,
+      color,
+      title,
+    });
+
+    const childKey = CHILD_KEYS.find((key) => Array.isArray(item[key]));
+    if (childKey) {
+      traversePlan(item[childKey], labelParts, depth + 1, collection);
+    }
+  });
+
+  return collection;
+}
+
+export function createPlanNodes(plan) {
+  return traversePlan(Array.isArray(plan) ? plan : []);
+}
+
+export function buildPlanLines(plan) {
+  const nodes = createPlanNodes(plan);
+  return nodes.map((node) => {
+    const indent = '  '.repeat(node.depth);
+    const titlePart = node.title ? ` ${node.title}` : '';
+    return `${indent}${node.symbol} ${node.label}.${titlePart}`.trimEnd();
+  });
+}
+
+export default {
+  createPlanNodes,
+  buildPlanLines,
+};

--- a/src/cli/components/progressUtils.js
+++ b/src/cli/components/progressUtils.js
@@ -1,0 +1,58 @@
+/**
+ * Plan progress helpers shared between Ink components and legacy console output.
+ */
+
+export function computeProgressState(progress) {
+  if (!progress || typeof progress !== 'object') {
+    return {
+      total: 0,
+      completed: 0,
+      normalized: 0,
+      filled: 0,
+      empty: 20,
+      ratio: 0,
+    };
+  }
+
+  const total = Number.isFinite(progress.totalSteps) ? Math.max(progress.totalSteps, 0) : 0;
+  const completed = Number.isFinite(progress.completedSteps) ? Math.max(progress.completedSteps, 0) : 0;
+  const providedRatio = Number.isFinite(progress.ratio) ? progress.ratio : null;
+  const ratio = providedRatio !== null ? providedRatio : total > 0 ? completed / total : 0;
+  const normalized = Math.min(1, Math.max(0, ratio));
+  const barWidth = 20;
+  let filled = Math.round(normalized * barWidth);
+  if (normalized > 0 && filled === 0) {
+    filled = 1;
+  }
+  if (normalized >= 1) {
+    filled = barWidth;
+  }
+  const empty = Math.max(0, barWidth - filled);
+
+  return {
+    total,
+    completed,
+    ratio,
+    normalized,
+    filled,
+    empty,
+  };
+}
+
+export function buildProgressLine(progress) {
+  const state = computeProgressState(progress);
+  if (state.total <= 0) {
+    return 'Plan progress: no active steps yet.';
+  }
+
+  const filledBar = state.filled > 0 ? '█'.repeat(state.filled) : '';
+  const emptyBar = state.empty > 0 ? '░'.repeat(state.empty) : '';
+  const percentLabel = `${Math.round(state.normalized * 100)}%`;
+  const summary = `${state.completed}/${state.total}`;
+  return `Plan progress: ${filledBar}${emptyBar} ${percentLabel} (${summary})`;
+}
+
+export default {
+  computeProgressState,
+  buildProgressLine,
+};

--- a/src/cli/context.md
+++ b/src/cli/context.md
@@ -9,8 +9,9 @@
 - `bootProbes/`: language/OS detectors that run before the agent loop to surface repo hints in CLI mode, include recommended tooling blurbs for detected stacks, and export a formatter so the detected context can enrich the system prompt. The JavaScript probe also reports whether helper refactoring binaries (comby, jscodeshift, ast-grep, acorn) are already available on the PATH, the Node.js probe summarises runtime/package-manager availability (node, npx, npm, pnpm, yarn, bun), and additional probes now cover Go, Rust, JVM build tooling, and containerisation signals.
 - `runtime.js`: wires the agent runtime to the terminal renderer and exports `agentLoop` plus command tracking helpers used by the CLI entry point.
 - `io.js`: readline wrapper with ESC detection (emits `ESCAPE_EVENT`, cancels active operations, highlights prompts).
-- `render.js`: Markdown-based renderer for plans/messages/command summaries and the plan progress bar.
-- `thinking.js`: spinner that displays elapsed time while awaiting API responses.
+- `components/`: Ink React components backing the CLI UI (`CliApp`, `Plan`, `Command`, etc.).
+- `render.js`: compatibility helpers that mirror the Ink output for tests and programmatic consumers.
+- `thinking.js`: legacy spinner used by non-Ink contexts that still import the CLI utilities.
 - `status.js`: prints transient status lines such as the remaining context window before issuing model requests.
 - `runner.js`: parses CLI arguments, runs boot probes to describe the workspace, forwards template/shortcut subcommands, funnels their summary into the system prompt, and launches the agent loop.
 

--- a/src/cli/render.js
+++ b/src/cli/render.js
@@ -1,18 +1,16 @@
 /**
- * Terminal rendering helpers responsible for formatting assistant output.
- *
- * Responsibilities:
- * - Provide a consistent boxed layout for messages, plans, and command details.
- * - Wrap LLM output in Markdown and syntax-highlight structured content.
- *
- * Consumers:
- * - `src/agent/loop.js` renders plans, messages, commands, and results using these helpers.
- * - Root `index.js` re-exports the helpers for unit testing.
+ * Terminal rendering helpers preserved for backwards compatibility with tests
+ * and programmatic consumers. The CLI itself now uses Ink components, but these
+ * functions reuse the same formatting logic so existing suites continue to work.
  */
 
 import chalk from 'chalk';
 import { marked } from 'marked';
 import markedTerminal from 'marked-terminal';
+
+import { createPlanNodes } from './components/planUtils.js';
+import { computeProgressState } from './components/progressUtils.js';
+import { buildCommandRenderData } from './components/commandUtils.js';
 
 const TerminalRenderer = markedTerminal.default || markedTerminal;
 
@@ -43,112 +41,43 @@ export function renderMarkdownMessage(message) {
   return marked.parse(prepared, { renderer: terminalRenderer });
 }
 
-export function renderPlan(plan) {
-  if (!Array.isArray(plan) || plan.length === 0) return;
-
-  const planLines = [];
-
-  const resolveStatusSymbol = (status) => {
-    const normalized = typeof status === 'string' ? status.toLowerCase() : '';
-
-    if (normalized === 'completed' || normalized === 'done') {
-      return chalk.green('✔');
-    }
-
-    if (normalized === 'running' || normalized === 'in_progress' || normalized === 'in-progress') {
-      return chalk.yellow('▶');
-    }
-
-    if (normalized === 'blocked' || normalized === 'failed' || normalized === 'error') {
-      return chalk.red('✖');
-    }
-
-    return chalk.gray('•');
-  };
-
-  const childKeys = ['substeps', 'children', 'steps'];
-
-  const traverse = (items, ancestors = [], depth = 0) => {
-    if (!Array.isArray(items) || items.length === 0) {
-      return;
-    }
-
-    items.forEach((item, index) => {
-      if (!item || typeof item !== 'object') {
-        return;
-      }
-
-      const rawStep = item.step !== undefined && item.step !== null ? String(item.step).trim() : '';
-      const sanitizedStep = rawStep.replace(/\.+$/, '');
-      const hasExplicitStep = sanitizedStep.length > 0;
-
-      const baseStep = hasExplicitStep ? sanitizedStep : String(index + 1);
-      const usesAbsolutePath = hasExplicitStep && sanitizedStep.includes('.');
-
-      const labelParts = usesAbsolutePath
-        ? sanitizedStep.split('.').filter((part) => part.length > 0)
-        : [...ancestors, baseStep];
-
-      const stepLabel = labelParts.join('.');
-
-      const indent = '  '.repeat(depth);
-      const statusSymbol = resolveStatusSymbol(item.status);
-      const title = chalk.white(item.title ?? '');
-
-      planLines.push(
-        `${indent}${statusSymbol} ${chalk.cyan(`${stepLabel}`)}${chalk.dim('.')} ${title}`,
-      );
-
-      const childKey = childKeys.find((key) => Array.isArray(item[key]));
-      if (childKey) {
-        traverse(item[childKey], labelParts, depth + 1);
-      }
-    });
-  };
-
-  traverse(plan);
-
-  if (planLines.length === 0) {
-    return;
+function colorizeSymbol(symbol, color) {
+  if (!color || typeof chalk[color] !== 'function') {
+    return symbol;
   }
-
-  display('Plan', planLines, 'cyan');
+  return chalk[color](symbol);
 }
 
-// Render a compact progress indicator so humans can track plan completion at a glance.
-export function renderPlanProgress(progress) {
-  if (!progress || typeof progress !== 'object') {
+export function renderPlan(plan) {
+  const nodes = createPlanNodes(plan);
+  if (nodes.length === 0) {
     return;
   }
 
-  const total = Number.isFinite(progress.totalSteps) ? progress.totalSteps : 0;
-  const completed = Number.isFinite(progress.completedSteps) ? progress.completedSteps : 0;
-  const ratio = Number.isFinite(progress.ratio)
-    ? progress.ratio
-    : total > 0
-      ? completed / total
-      : 0;
+  const lines = nodes.map((node) => {
+    const indent = '  '.repeat(node.depth);
+    const symbol = colorizeSymbol(node.symbol, node.color);
+    const label = chalk.cyan(node.label);
+    const dot = chalk.dim('.');
+    const title = node.title ? ` ${chalk.white(node.title)}` : '';
+    return `${indent}${symbol} ${label}${dot}${title}`.trimEnd();
+  });
 
-  if (total <= 0) {
+  display('Plan', lines, 'cyan');
+}
+
+export function renderPlanProgress(progress) {
+  const state = computeProgressState(progress);
+
+  if (state.total <= 0) {
     console.log(chalk.blueBright('Plan progress: ') + chalk.dim('no active steps yet.'));
     return;
   }
 
-  const normalized = Math.min(1, Math.max(0, ratio));
-  const barWidth = 20;
-  let filled = Math.round(normalized * barWidth);
-  if (normalized > 0 && filled === 0) {
-    filled = 1;
-  }
-  if (normalized >= 1) {
-    filled = barWidth;
-  }
-  const empty = Math.max(0, barWidth - filled);
-
-  const filledBar = filled > 0 ? chalk.green('█'.repeat(filled)) : '';
-  const emptyBar = empty > 0 ? chalk.gray('░'.repeat(empty)) : '';
-  const percentLabel = `${Math.round(normalized * 100)}%`;
-  const summary = `${completed}/${total}`;
+  const filledBar = state.filled > 0 ? chalk.green('█'.repeat(state.filled)) : '';
+  const emptyBar = state.empty > 0 ? chalk.gray('░'.repeat(state.empty)) : '';
+  const percentLabel = `${Math.round(state.normalized * 100)}%`;
+  const summary = `${state.completed}/${state.total}`;
 
   console.log(
     `${chalk.blueBright('Plan progress: ')}${filledBar}${emptyBar} ${chalk.bold(percentLabel)} (${summary})`,
@@ -184,189 +113,28 @@ function indentLine(text) {
   return chalk.dim(`   ${text}`);
 }
 
-function exitCodeLine(code) {
+function exitCodeLine(line) {
   const prefix = chalk.dim('   ');
-  const colorize = code === 0 ? chalk.green : chalk.red;
-  return `${prefix}${colorize(`Exit code: ${code}`)}`;
+  const colorize = line.status === 'success' ? chalk.green : chalk.red;
+  return `${prefix}${colorize(line.text)}`;
 }
 
-function pluralize(word, count) {
-  return `${word}${count === 1 ? '' : 's'}`;
-}
-
-function normalizePreviewLines(preview) {
-  if (!preview) {
-    return [];
-  }
-  const lines = String(preview).split('\n');
-  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
-    lines.pop();
-  }
-  return lines;
-}
-
-function collectReadPaths(spec) {
-  const paths = [];
-  if (!spec || typeof spec !== 'object') {
-    return paths;
-  }
-
-  const addPath = (candidate) => {
-    if (typeof candidate !== 'string') {
-      return;
+function formatSummaryLines(summaryLines) {
+  return summaryLines.map((line) => {
+    switch (line.kind) {
+      case 'error-arrow':
+        return errorArrowLine(line.text);
+      case 'error-indent':
+        return errorIndentLine(line.text);
+      case 'exit-code':
+        return exitCodeLine(line);
+      case 'indent':
+        return indentLine(line.text);
+      case 'arrow':
+      default:
+        return arrowLine(line.text);
     }
-    const trimmed = candidate.trim();
-    if (!trimmed || paths.includes(trimmed)) {
-      return;
-    }
-    paths.push(trimmed);
-  };
-
-  addPath(spec.path);
-  if (Array.isArray(spec.paths)) {
-    for (const candidate of spec.paths) {
-      addPath(candidate);
-    }
-  }
-
-  return paths;
-}
-
-function parseReadSegments(stdout) {
-  if (!stdout) {
-    return [];
-  }
-
-  const lines = String(stdout).split('\n');
-  const segments = [];
-  let current = null;
-
-  for (const line of lines) {
-    if (line.endsWith(':::')) {
-      if (current) {
-        const { path, content } = current;
-        while (content.length > 0 && content[content.length - 1] === '') {
-          content.pop();
-        }
-        segments.push({ path, lineCount: content.length });
-      }
-      current = { path: line.slice(0, -3), content: [] };
-    } else if (current) {
-      current.content.push(line);
-    }
-  }
-
-  if (current) {
-    const { path, content } = current;
-    while (content.length > 0 && content[content.length - 1] === '') {
-      content.pop();
-    }
-    segments.push({ path, lineCount: content.length });
-  }
-
-  return segments;
-}
-
-function inferCommandType(command) {
-  if (!command || typeof command !== 'object') {
-    return 'EXECUTE';
-  }
-
-  if (command.edit) return 'EDIT';
-  if (command.read) return 'READ';
-  if (command.replace) return 'REPLACE';
-
-  const runValue = typeof command.run === 'string' ? command.run.trim() : '';
-  if (runValue) {
-    const keyword = runValue.split(/\s+/)[0]?.toLowerCase();
-    if (keyword === 'read') {
-      return 'READ';
-    }
-  }
-
-  return 'EXECUTE';
-}
-
-function buildHeadingDetail(type, execution, command) {
-  switch (type) {
-    case 'READ': {
-      const spec = execution?.spec || command?.read || {};
-      const paths = collectReadPaths(spec);
-      return `([${paths.join(', ')}])`;
-    }
-    case 'EDIT': {
-      const spec = execution?.spec || command?.edit || {};
-      const parts = [];
-      if (spec.path) {
-        parts.push(spec.path);
-      }
-      if (spec.encoding) {
-        parts.push(spec.encoding);
-      }
-      const editCount = Array.isArray(spec.edits) ? spec.edits.length : 0;
-      parts.push(`${editCount} ${pluralize('edit', editCount)}`);
-      return `(${parts.join(', ')})`;
-    }
-    case 'REPLACE': {
-      const spec = execution?.spec || command?.replace || {};
-      const parts = [];
-      if (spec.pattern !== undefined) {
-        parts.push(`pattern: ${JSON.stringify(spec.pattern ?? '')}`);
-      }
-      if (spec.replacement !== undefined) {
-        parts.push(`replacement: ${JSON.stringify(spec.replacement ?? '')}`);
-      }
-      const files = Array.isArray(spec.files) ? spec.files.filter(Boolean) : [];
-      if (files.length > 0) {
-        parts.push(`[${files.join(', ')}]`);
-      }
-      if (spec.dry_run || spec.dryRun) {
-        parts.push('dry-run');
-      }
-      return `(${parts.join(', ')})`;
-    }
-    default: {
-      const runValue =
-        (execution?.command && typeof execution.command.run === 'string'
-          ? execution.command.run
-          : typeof command?.run === 'string'
-            ? command.run
-            : '') || '';
-      const trimmed = runValue.trim();
-      return `(${trimmed || 'shell command'})`;
-    }
-  }
-}
-
-function extractCommandDescription(command, execution) {
-  const candidates = [
-    command?.description,
-    execution?.command?.description,
-    execution?.description,
-  ];
-
-  for (const candidate of candidates) {
-    if (typeof candidate === 'string') {
-      const trimmed = candidate.trim();
-      if (trimmed) {
-        return trimmed;
-      }
-    }
-  }
-
-  return '';
-}
-
-function appendStdErr(summaryLines, stderrPreview) {
-  const stderrLines = normalizePreviewLines(stderrPreview);
-  if (stderrLines.length === 0) {
-    return;
-  }
-
-  summaryLines.push(errorArrowLine(`STDERR: ${stderrLines[0]}`));
-  for (const line of stderrLines.slice(1)) {
-    summaryLines.push(errorIndentLine(line));
-  }
+  });
 }
 
 export function renderCommand(command, result, output = {}) {
@@ -374,100 +142,21 @@ export function renderCommand(command, result, output = {}) {
     return;
   }
 
-  const execution = output.execution || {};
-  const type = (execution.type || inferCommandType(command)).toUpperCase();
-  const detail = buildHeadingDetail(type, execution, command);
-  const description = extractCommandDescription(command, execution);
-  const summaryLines = [];
-
-  if (type === 'READ') {
-    const filtersApplied = Boolean(command?.filter_regex || command?.tail_lines);
-    const spec = execution?.spec || command?.read || {};
-    const paths = collectReadPaths(spec);
-
-    let segments = parseReadSegments(output.stdout);
-    if (segments.length === 0 && !filtersApplied && result?.stdout) {
-      const fallbackSegments = parseReadSegments(result.stdout);
-      if (fallbackSegments.length > 0) {
-        segments = fallbackSegments;
-      }
-    }
-
-    if (segments.length > 0) {
-      const totalLines = segments.reduce((acc, item) => acc + item.lineCount, 0);
-      summaryLines.push(
-        arrowLine(
-          `Read ${totalLines} ${pluralize('line', totalLines)} from ${segments.length} ${pluralize(
-            'file',
-            segments.length,
-          )}.`,
-        ),
-      );
-      for (const segment of segments) {
-        const label = segment.path || '(unknown path)';
-        summaryLines.push(
-          indentLine(`${label}: ${segment.lineCount} ${pluralize('line', segment.lineCount)}`),
-        );
-      }
-    } else if (paths.length > 0) {
-      const fileCount = paths.length;
-      const baseMessage = filtersApplied
-        ? `No lines matched the applied filters across ${fileCount} ${pluralize('file', fileCount)}.`
-        : `Read 0 lines from ${fileCount} ${pluralize('file', fileCount)}.`;
-      summaryLines.push(arrowLine(baseMessage));
-      for (const label of paths) {
-        summaryLines.push(indentLine(`${label}: 0 lines`));
-      }
-    }
-  } else if (type === 'EDIT' || type === 'REPLACE') {
-    const stdoutLines = normalizePreviewLines(output.stdoutPreview);
-    if (stdoutLines.length > 0) {
-      summaryLines.push(arrowLine(stdoutLines[0]));
-      for (const line of stdoutLines.slice(1)) {
-        summaryLines.push(indentLine(line));
-      }
-    }
-  } else {
-    const stdoutLines = normalizePreviewLines(output.stdoutPreview);
-    if (stdoutLines.length > 0) {
-      summaryLines.push(arrowLine(stdoutLines[0]));
-      if (stdoutLines.length > 2) {
-        const middleCount = stdoutLines.length - 2;
-        summaryLines.push(indentLine(`+ ${middleCount} more ${pluralize('line', middleCount)}`));
-      }
-      if (stdoutLines.length > 1) {
-        summaryLines.push(indentLine(stdoutLines[stdoutLines.length - 1]));
-      }
-    }
+  const execution = output?.execution || {};
+  const data = buildCommandRenderData(command, result, output, execution);
+  if (!data) {
+    return;
   }
 
-  if (summaryLines.length === 0 && result?.exit_code === 0 && !output.stderrPreview) {
-    summaryLines.push(arrowLine('Command completed successfully.'));
-  }
-
-  if (output.stderrPreview) {
-    appendStdErr(summaryLines, output.stderrPreview);
-  }
-
-  if (result) {
-    if (typeof result.exit_code === 'number') {
-      summaryLines.push(exitCodeLine(result.exit_code));
-    }
-    if (result.killed) {
-      summaryLines.push(indentLine('Process terminated (timeout).'));
-    }
-  }
-
-  if (summaryLines.length === 0) {
-    summaryLines.push(arrowLine('No output.'));
-  }
-
+  const { type, detail, description, summaryLines } = data;
   const lines = [];
+
   if (description) {
     lines.push(` ${chalk.blueBright(chalk.bold('DESCRIPTION'))} ${chalk.white(description)}`);
   }
+
   lines.push(formatHeading(type, detail));
-  lines.push(...summaryLines);
+  lines.push(...formatSummaryLines(summaryLines));
 
   console.log('');
   console.log(lines.join('\n'));
@@ -480,4 +169,5 @@ export default {
   renderPlan,
   renderMessage,
   renderCommand,
+  renderPlanProgress,
 };

--- a/src/cli/runtime.js
+++ b/src/cli/runtime.js
@@ -1,4 +1,5 @@
-import chalk from 'chalk';
+import React from 'react';
+import { render } from 'ink';
 
 import {
   getAutoApproveFlag,
@@ -8,10 +9,6 @@ import {
   setNoHumanFlag,
 } from '../lib/startupFlags.js';
 import { createAgentRuntime } from '../agent/loop.js';
-import { startThinking, stopThinking } from './thinking.js';
-import { createInterface, askHuman, ESCAPE_EVENT } from './io.js';
-import { renderPlan, renderMessage, renderCommand, renderPlanProgress } from './render.js';
-import { renderRemainingContext } from './status.js';
 import { runCommand, runRead } from '../commands/run.js';
 import {
   isPreapprovedCommand,
@@ -21,6 +18,7 @@ import {
 } from '../services/commandApprovalService.js';
 import { applyFilter, tailLines } from '../utils/text.js';
 import { incrementCommandCount } from '../services/commandStatsService.js';
+import CliApp from './components/CliApp.js';
 
 export async function runCommandAndTrack(run, cwd = '.', timeoutSec = 60) {
   const result = await runCommand(run, cwd, timeoutSec);
@@ -53,126 +51,36 @@ async function runAgentLoopWithCurrentDependencies(options = {}) {
     ...options,
   });
 
-  const rl = createInterface();
-  const handleEscape = (payload) => {
-    runtime.cancel({ reason: 'escape-key', payload });
-  };
-  rl.on(ESCAPE_EVENT, handleEscape);
+  return new Promise((resolve, reject) => {
+    let settled = false;
 
-  const outputProcessor = (async () => {
-    for await (const event of runtime.outputs) {
-      if (!event || typeof event !== 'object') continue;
-
-      switch (event.type) {
-        case 'banner':
-          if (event.title) {
-            console.log(chalk.bold.blue(`\n${event.title}`));
-          }
-          if (event.subtitle) {
-            console.log(chalk.dim(event.subtitle));
-          }
-          break;
-        case 'status': {
-          const message = event.message ?? '';
-          if (!message) break;
-          if (event.level === 'warn') {
-            console.log(chalk.yellow(message));
-          } else if (event.level === 'error') {
-            console.log(chalk.red(message));
-          } else if (event.level === 'success') {
-            console.log(chalk.green(message));
-          } else {
-            console.log(message);
-          }
-          if (event.details) {
-            console.log(chalk.dim(String(event.details)));
-          }
-          break;
-        }
-        case 'thinking':
-          if (event.state === 'start') {
-            startThinking();
-          } else {
-            stopThinking();
-          }
-          break;
-        case 'assistant-message':
-          renderMessage(event.message ?? '');
-          break;
-        case 'plan':
-          renderPlan(Array.isArray(event.plan) ? event.plan : []);
-          break;
-        case 'plan-progress':
-          renderPlanProgress(event.progress);
-          break;
-        case 'context-usage':
-          if (event.usage) {
-            renderRemainingContext(event.usage);
-          }
-          break;
-        case 'command-result':
-          renderCommand(event.command, event.result, {
-            ...(event.preview || {}),
-            execution: event.execution,
-          });
-          break;
-        case 'error': {
-          const base = event.message || 'Agent error encountered.';
-          console.error(chalk.red(base));
-          if (event.details) {
-            console.error(chalk.dim(String(event.details)));
-          }
-          if (event.raw) {
-            console.error(chalk.dim(String(event.raw)));
-          }
-          break;
-        }
-        case 'request-input': {
-          const prompt = event.prompt ?? '\n ▷ ';
-          const answer = await askHuman(rl, prompt);
-          runtime.submitPrompt(answer);
-          break;
-        }
-        case 'debug': {
-          const payload = event.payload;
-          let formatted = '';
-          if (typeof payload === 'string') {
-            formatted = payload;
-          } else {
-            try {
-              formatted = JSON.stringify(payload, null, 2);
-            } catch {
-              formatted = String(payload);
-            }
-          }
-          if (formatted) {
-            console.log(chalk.gray(`[debug] ${formatted}`));
-          }
-          break;
-        }
-        default:
-          break;
+    const handleResolve = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
       }
-    }
-  })();
+    };
 
-  let outputError = null;
-  try {
-    await runtime.start();
-  } finally {
-    rl.off?.(ESCAPE_EVENT, handleEscape);
-    rl.close?.();
-    stopThinking();
-    try {
-      await outputProcessor;
-    } catch (err) {
-      outputError = err;
-    }
-  }
+    const handleReject = (error) => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    };
 
-  if (outputError) {
-    throw outputError;
-  }
+    const app = render(
+      React.createElement(CliApp, {
+        runtime,
+        onRuntimeComplete: handleResolve,
+        onRuntimeError: handleReject,
+      }),
+      { exitOnCtrlC: false },
+    );
+
+    app.waitUntilExit().catch((error) => {
+      handleReject(error);
+    });
+  });
 }
 
 export async function agentLoop(options) {


### PR DESCRIPTION
## Summary
- replace the CLI runtime with an Ink-powered app that drives rendering and input
- add React component hierarchy for plans, commands, human prompts, and debug output, sharing formatting helpers
- update legacy render helpers and documentation while wiring new Ink/react dependencies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5e58339bc8328bd527d907821af19