### PR TITLE
Fix InkTextArea keyboard handling

### DIFF
--- a/context.md
+++ b/context.md
@@ -16,6 +16,7 @@
 - Comprehensive automated coverage: unit suites exercise nearly every agent subsystem while integration tests validate the full runtime loop with mocked OpenAI responses.
 - Clear separation between transport (`src/bindings`), presentation (`src/cli`), agent orchestration (`src/agent`), and side effects (`src/commands`, `src/services`).
 - Documentation spans architecture, ops, and prompt maintenance, reducing ramp-up time for new contributors (especially AI assistants).
+- CLI unit tests now use `ink-testing-library` to simulate terminal input when exercising interactive components.
 
 ## Risks / Gaps
 - Runtime behavior depends on persisted state in `.openagent/plan.json`; stale snapshots can confuse follow-up sessions and tests if not cleaned between runs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "esprima": "^4.0.1",
         "globals": "^16.4.0",
+        "ink-testing-library": "^4.0.0",
         "jest": "^29.7.0",
         "lint-staged": "^16.2.3",
         "prettier": "^3.2.5"
@@ -4328,6 +4329,24 @@
       "peerDependencies": {
         "ink": ">=4.0.0",
         "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/ink/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "esprima": "^4.0.1",
     "globals": "^16.4.0",
+    "ink-testing-library": "^4.0.0",
     "jest": "^29.7.0",
     "lint-staged": "^16.2.3",
     "prettier": "^3.2.5"

--- a/src/cli/components/InkTextArea.js
+++ b/src/cli/components/InkTextArea.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Text, useInput } from 'ink';
 
 const h = React.createElement;
@@ -97,13 +97,16 @@ export function InkTextArea({
     };
   }, [interactive]);
 
-  const updateValue = (nextValue, nextCaretIndex) => {
-    const clampedIndex = clamp(nextCaretIndex, 0, nextValue.length);
-    onChange?.(nextValue);
-    setCaretIndex(clampedIndex);
-  };
+  const updateValue = useCallback(
+    (nextValue, nextCaretIndex) => {
+      const clampedIndex = clamp(nextCaretIndex, 0, nextValue.length);
+      onChange?.(nextValue);
+      setCaretIndex(clampedIndex);
+    },
+    [onChange],
+  );
 
-  useInput(
+  const handleInput = useCallback(
     (input, key) => {
       if (!interactive) {
         return;
@@ -196,8 +199,20 @@ export function InkTextArea({
         updateValue(nextValue, caretIndex + input.length);
       }
     },
-    { isActive: interactive },
+    [
+      caretColumnRef,
+      caretIndex,
+      caretPosition.column,
+      caretPosition.line,
+      interactive,
+      onSubmit,
+      positions,
+      updateValue,
+      value,
+    ],
   );
+
+  useInput(handleInput, { isActive: interactive });
 
   const hasValue = value.length > 0;
   const caretGlyph = interactive && showCaret ? '▌' : '';

--- a/src/cli/components/context.md
+++ b/src/cli/components/context.md
@@ -10,7 +10,8 @@
 - `Command.js`, `renderCommand.js`, `commandUtils.js` — pretty-print shell/read commands with highlights and approval status.
 - `ContextUsage.js` — displays token usage (remaining context window) tracked by `contextUsage` utilities.
 - `DebugPanel.js`, `ThinkingIndicator.js` — optional diagnostics and spinner overlays.
-- `InkTextArea.js`, `AskHuman.js` — capture human inputs and approval decisions.
+- `InkTextArea.js`, `AskHuman.js` — capture human inputs and approval decisions. The text area now keeps its `useInput`
+  handler memoized so keystrokes always update the caret and value correctly.
 
 ## Positive Signals
 - Components are decomposed by concern, enabling targeted tests and easier adjustments to CLI layout.

--- a/tests/context.md
+++ b/tests/context.md
@@ -7,6 +7,7 @@
 - `integration/` — orchestrates full agent runs using a mocked OpenAI backend. See [`integration/context.md`](integration/context.md).
 - `unit/` — targeted tests for utilities, CLI rendering, OpenAI adapters, etc. See [`unit/context.md`](unit/context.md).
 - `mockOpenAI.js` — fixture exposing deterministic OpenAI responses for integration harnesses.
+- `ink-testing-library` dev dependency drives terminal keystroke simulation for CLI component specs.
 
 ## Positive Signals
 - Integration harness (`agentRuntimeTestHarness.js`) simulates CLI runtime, ensuring plan updates, command execution, and cancellation all cooperate.

--- a/tests/unit/context.md
+++ b/tests/unit/context.md
@@ -6,7 +6,7 @@
 ## Key Groupings
 - Agent core: `commandExecution.test.js`, `approvalManager.test.js`, `responseParser.test.js`, `responseValidator.test.js`.
 - Planning & context: `plan.test.js`, `planUtils.test.js`, `agentPlanProgress.test.js`, `contextUsage.test.js`.
-- CLI/UI: `renderCommand.test.js`, `renderPlan.test.js`, `renderLanguage.test.js`, `CliApp` component tests.
+- CLI/UI: `renderCommand.test.js`, `renderPlan.test.js`, `renderLanguage.test.js`, `CliApp` component tests, `inkTextArea.test.js` for keyboard handling.
 - Utilities: `outputUtils.test.js`, `readSpec.test.js`, `runCommand.test.js`, `cancellation.test.js`.
 - Integrations: `websocketBinding.test.js`, `httpClient.test.js`, `openaiRequest.test.js`, `openaiResponses.test.js`.
 

--- a/tests/unit/inkTextArea.test.js
+++ b/tests/unit/inkTextArea.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { describe, expect, jest, test } from '@jest/globals';
+import { render } from 'ink-testing-library';
+import InkTextArea from '../../src/cli/components/InkTextArea.js';
+
+describe('InkTextArea input handling', () => {
+  async function flush() {
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  test('captures character input and notifies onChange', async () => {
+    const handleChange = jest.fn();
+
+    const { stdin, unmount } = render(
+      React.createElement(InkTextArea, {
+        value: '',
+        onChange: handleChange,
+        onSubmit: jest.fn(),
+      }),
+    );
+
+    stdin.write('a');
+    await flush();
+
+    expect(handleChange).toHaveBeenCalledWith('a');
+
+    unmount();
+  });
+
+  test('submits the current value on enter', async () => {
+    const handleSubmit = jest.fn();
+
+    const { stdin, unmount } = render(
+      React.createElement(InkTextArea, {
+        value: 'ready',
+        onChange: jest.fn(),
+        onSubmit: handleSubmit,
+      }),
+    );
+
+    stdin.write('\r');
+    await flush();
+
+    expect(handleSubmit).toHaveBeenCalledWith('ready');
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- memoize the InkTextArea input handler so caret updates reflect every keystroke
- add ink-testing-library-based unit tests for InkTextArea and document the new tooling in project context files

## Testing
- npm test -- inkTextArea

------
https://chatgpt.com/codex/tasks/task_e_68e6609017f08328a1fb1607769b23e8