### PR TITLE
Fix command timeline box stretching

### DIFF
--- a/src/cli/components/Command.js
+++ b/src/cli/components/Command.js
@@ -53,7 +53,16 @@ export function Command({ command, result, preview = {}, execution = {} }) {
 
   return h(
     Box,
-    { flexDirection: 'column', marginTop: 1, paddingX: 1, paddingY: 1, backgroundColor: 'black' },
+    {
+      flexDirection: 'column',
+      marginTop: 1,
+      paddingX: 1,
+      paddingY: 1,
+      backgroundColor: 'black',
+      width: '100%',
+      alignSelf: 'stretch',
+      flexGrow: 1,
+    },
     children,
   );
 }

--- a/src/cli/components/context.md
+++ b/src/cli/components/context.md
@@ -21,6 +21,10 @@
 - Rendering relies on Ink’s flexbox-like layout; test visually after major styling changes to avoid clipping.
 - Markdown rendering leverages `renderMarkdownMessage` helpers; ensure new components respect sanitization rules.
 
+## Maintenance Notes
+- Layout wrappers such as `Command` explicitly set `width: '100%'`/`alignSelf: 'stretch'` so timeline entries fill the
+  terminal width consistently.
+
 ## Related Context
 - UI render helpers: [`../render.js`](../render.js).
 - Runtime event producer: [`../../agent/context.md`](../../agent/context.md).


### PR DESCRIPTION
## Summary
- ensure the command timeline box stretches to the full terminal width for consistent layout
- document the new layout requirement in the CLI components context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66796911c83289f4d52b806bc7d1d