### PR TITLE
Add Go console runtime mirroring core agent loop

### DIFF
--- a/context.md
+++ b/context.md
@@ -13,6 +13,7 @@
 - `packages/web/` — Bundled frontend/backend web experience orchestrator. See [`packages/web/context.md`](packages/web/context.md).
 - `tests/` — cross-package integration suites with mock OpenAI harnesses. See [`tests/context.md`](tests/context.md).
 - `packages/core/prompts/` & `schemas/` — authoritative protocol prompts plus JSON schema for validation. Linked details in [`packages/core/prompts/context.md`](packages/core/prompts/context.md) and [`schemas/context.md`](schemas/context.md).
+- `golang/` — Go workspace that mirrors the core runtime with a console entrypoint using the same structured tool schema. See [`golang/context.md`](golang/context.md).
 - `docs/` — design notes, operational guides, and meta documentation for contributors. See [`docs/context.md`](docs/context.md).
 - Editing helpers now live under `packages/core/scripts/`; root `scripts/` retains repo maintenance utilities (JSON validation, release safety checks). See [`packages/core/scripts/context.md`](packages/core/scripts/context.md) and [`scripts/context.md`](scripts/context.md).
 - Operational metadata: `.github/` workflows and `.openagent/` runtime plan snapshots. JetBrains `.idea/`

--- a/golang/cmd/openagent/main.go
+++ b/golang/cmd/openagent/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/asynkron/openagent/golang/internal/core/runtime"
+)
+
+// main bootstraps the Go translation of the OpenAgent runtime.
+func main() {
+	var (
+		model              = flag.String("model", "gpt-4.1", "OpenAI model identifier to use for responses")
+		autoApprove        = flag.Bool("auto-approve", false, "execute plan steps without manual confirmation")
+		noHuman            = flag.Bool("no-human", false, "operate without waiting for user input between passes")
+		promptAugmentation = flag.String("augment", "", "additional system prompt instructions appended after the default prompt")
+		planReminder       = flag.String("plan-reminder", "", "message sent when the plan stalls with no human present")
+		autoMessage        = flag.String("auto-message", "", "auto-response sent when no human is available")
+	)
+	flag.Parse()
+
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "OPENAI_API_KEY must be set in the environment.")
+		os.Exit(1)
+	}
+
+	options := runtime.RuntimeOptions{
+		APIKey:                   apiKey,
+		Model:                    *model,
+		AutoApprove:              *autoApprove,
+		NoHuman:                  *noHuman,
+		SystemPromptAugmentation: *promptAugmentation,
+		PlanReminderMessage:      *planReminder,
+		NoHumanAutoMessage:       *autoMessage,
+	}
+
+	agent, err := runtime.NewRuntime(options)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create runtime: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := agent.Run(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/golang/context.md
+++ b/golang/context.md
@@ -1,0 +1,22 @@
+# Directory Context: golang
+
+## Purpose & Scope
+
+- Hosts a Go implementation of the OpenAgent core runtime plus a console entrypoint.
+- Mirrors the behaviour of `packages/core` in TypeScript: prompts the model using the canonical tool schema, executes plan steps, and surfaces observations.
+
+## Key Subdirectories
+
+- `cmd/openagent/` — CLI wrapper that reads flags, pulls the API key from `OPENAI_API_KEY`, and starts the runtime.
+- `internal/core/` — Go translation of the core runtime contracts and loop. Contains the plan manager, OpenAI client wrapper, command executor, and shared schema constants.
+
+## Usage Notes
+
+- Run `go run ./cmd/openagent` (inside `golang/`) after exporting `OPENAI_API_KEY`. Flags mirror the CLI experience: `--auto-approve`, `--no-human`, `--augment`, `--plan-reminder`, and `--auto-message`.
+- The runtime relies on the Chat Completions API and enforces the exact JSON schema defined in the TypeScript workspace to keep responses aligned across implementations.
+- Command execution currently shells out via `exec.CommandContext` with `-c`; adjust the executor if a different shell strategy is required on Windows.
+
+## Maintenance Notes
+
+- Whenever the TypeScript schema changes, update `internal/core/schema/schema.go` and the accompanying constants to preserve parity.
+- `internal/core/runtime/runtime.go` keeps the loop readable by delegating plan execution to `plan_manager.go` and observations to `command_executor.go`; mimic that separation for future features (virtual commands, approvals, etc.).

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -1,0 +1,3 @@
+module github.com/asynkron/openagent/golang
+
+go 1.22

--- a/golang/internal/core/runtime/command_executor.go
+++ b/golang/internal/core/runtime/command_executor.go
@@ -1,0 +1,158 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// CommandExecutor runs shell commands described by plan steps.
+type CommandExecutor struct{}
+
+// NewCommandExecutor builds the default executor that shells out using exec.CommandContext.
+func NewCommandExecutor() *CommandExecutor {
+	return &CommandExecutor{}
+}
+
+// Execute runs the provided command and returns stdout/stderr observations.
+func (e *CommandExecutor) Execute(ctx context.Context, step PlanStep) (PlanObservationPayload, error) {
+	if strings.TrimSpace(step.Command.Shell) == "" || strings.TrimSpace(step.Command.Run) == "" {
+		return PlanObservationPayload{}, fmt.Errorf("command: invalid shell or run for step %s", step.ID)
+	}
+	cmd := exec.CommandContext(ctx, step.Command.Shell, "-c", step.Command.Run)
+	if step.Command.Cwd != "" {
+		cmd.Dir = step.Command.Cwd
+	}
+
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	timeout := time.Duration(step.Command.TimeoutSec) * time.Second
+	if timeout <= 0 {
+		timeout = time.Minute
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if err := cmd.Start(); err != nil {
+		return PlanObservationPayload{}, fmt.Errorf("command: start: %w", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	var runErr error
+	select {
+	case <-runCtx.Done():
+		_ = cmd.Process.Kill()
+		runErr = fmt.Errorf("command: timeout after %s", timeout)
+	case err := <-done:
+		runErr = err
+	}
+
+	stdout := stdoutBuf.Bytes()
+	stderr := stderrBuf.Bytes()
+
+	filteredStdout := applyFilter(stdout, step.Command.FilterRegex)
+	filteredStderr := applyFilter(stderr, step.Command.FilterRegex)
+
+	truncatedStdout, truncated := truncateOutput(filteredStdout, step.Command.MaxBytes, step.Command.TailLines)
+	truncatedStderr, stderrTruncated := truncateOutput(filteredStderr, step.Command.MaxBytes, step.Command.TailLines)
+	truncated = truncated || stderrTruncated
+
+	observation := PlanObservationPayload{
+		Stdout:    string(truncatedStdout),
+		Stderr:    string(truncatedStderr),
+		Truncated: truncated,
+		Plan:      nil,
+	}
+
+	if exitErr := (&exec.ExitError{}); errors.As(runErr, &exitErr) {
+		code := exitErr.ExitCode()
+		observation.ExitCode = &code
+	} else if runErr == nil {
+		zero := 0
+		observation.ExitCode = &zero
+	}
+
+	if runErr != nil && !errors.As(runErr, &exec.ExitError{}) {
+		observation.Details = runErr.Error()
+	}
+
+	return observation, runErr
+}
+
+func applyFilter(output []byte, pattern string) []byte {
+	if pattern == "" {
+		return output
+	}
+	rx, err := regexp.Compile(pattern)
+	if err != nil {
+		return output
+	}
+	lines := strings.Split(string(output), "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if rx.MatchString(line) {
+			kept = append(kept, line)
+		}
+	}
+	return []byte(strings.Join(kept, "\n"))
+}
+
+func truncateOutput(output []byte, maxBytes, tailLines int) ([]byte, bool) {
+	if len(output) == 0 {
+		return output, false
+	}
+	truncated := false
+	if maxBytes > 0 && len(output) > maxBytes {
+		output = output[len(output)-maxBytes:]
+		truncated = true
+	}
+
+	if tailLines <= 0 {
+		return output, truncated
+	}
+
+	lines := bytes.Split(output, []byte("\n"))
+	if len(lines) > tailLines {
+		lines = lines[len(lines)-tailLines:]
+		truncated = true
+	}
+
+	return bytes.Join(lines, []byte("\n")), truncated
+}
+
+// BuildToolMessage marshals the observation into a JSON string ready for tool messages.
+func BuildToolMessage(observation PlanObservationPayload) (string, error) {
+	buf := bytes.Buffer{}
+	encoder := jsonEncoder(&buf)
+	if err := encoder.Encode(PlanObservation{ObservationForLLM: &observation}); err != nil {
+		return "", err
+	}
+	result := strings.TrimSpace(buf.String())
+	if result == "" {
+		result = "{}"
+	}
+	return result, nil
+}
+
+// jsonEncoder wraps json.NewEncoder to delay importing encoding/json in callers without needing generics.
+func jsonEncoder(w io.Writer) *json.Encoder {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc
+}

--- a/golang/internal/core/runtime/constants.go
+++ b/golang/internal/core/runtime/constants.go
@@ -1,0 +1,15 @@
+package runtime
+
+const (
+    // DefaultCommandTailLines matches the JavaScript runtime default tail length.
+    DefaultCommandTailLines = 200
+    // DefaultCommandMaxBytes mirrors the 16KiB cap used by the TypeScript runtime.
+    DefaultCommandMaxBytes = 16 * 1024
+)
+
+const (
+    // DefaultPlanReminder reproduces the "waiting for execution" reminder used when the agent stalls.
+    DefaultPlanReminder = "The plan has pending steps but nothing is executing. Continue the plan or request input if needed."
+    // DefaultNoHumanAutoMessage is sent when the runtime operates without human input.
+    DefaultNoHumanAutoMessage = "No human is currently available. Continue autonomously while respecting safety constraints."
+)

--- a/golang/internal/core/runtime/openai_client.go
+++ b/golang/internal/core/runtime/openai_client.go
@@ -1,0 +1,201 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/asynkron/openagent/golang/internal/core/schema"
+)
+
+// OpenAIClient wraps the HTTP client required to call the Chat Completions API.
+type OpenAIClient struct {
+	apiKey     string
+	model      string
+	httpClient *http.Client
+	tool       schema.ToolDefinition
+	baseURL    string
+}
+
+// NewOpenAIClient configures the client with the provided API key and model identifier.
+func NewOpenAIClient(apiKey, model string) (*OpenAIClient, error) {
+	if apiKey == "" {
+		return nil, errors.New("openai: API key is required")
+	}
+	if model == "" {
+		return nil, errors.New("openai: model is required")
+	}
+	tool, err := schema.Definition()
+	if err != nil {
+		return nil, err
+	}
+	return &OpenAIClient{
+		apiKey: apiKey,
+		model:  model,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+		tool:    tool,
+		baseURL: "https://api.openai.com/v1/chat/completions",
+	}, nil
+}
+
+// RequestPlan sends the accumulated chat history to OpenAI and returns the structured plan response.
+func (c *OpenAIClient) RequestPlan(ctx context.Context, history []ChatMessage) (*PlanResponse, ToolCall, error) {
+	payload := chatCompletionRequest{
+		Model:    c.model,
+		Messages: buildMessages(history),
+		Tools: []toolSpecification{{
+			Type:     "function",
+			Function: functionDefinition{Name: c.tool.Name, Description: c.tool.Description, Parameters: c.tool.Parameters},
+		}},
+		ToolChoice: toolChoice{Type: "function", Function: &toolChoiceFunction{Name: c.tool.Name}},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, ToolCall{}, fmt.Errorf("openai: encode request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, ToolCall{}, fmt.Errorf("openai: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, ToolCall{}, fmt.Errorf("openai: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+		return nil, ToolCall{}, fmt.Errorf("openai: status %s: %s", resp.Status, string(msg))
+	}
+
+	var completion chatCompletionResponse
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&completion); err != nil {
+		return nil, ToolCall{}, fmt.Errorf("openai: decode response: %w", err)
+	}
+
+	if len(completion.Choices) == 0 {
+		return nil, ToolCall{}, errors.New("openai: response contained no choices")
+	}
+	choice := completion.Choices[0]
+	if len(choice.Message.ToolCalls) == 0 {
+		return nil, ToolCall{}, errors.New("openai: assistant did not call the tool")
+	}
+
+	toolCall := choice.Message.ToolCalls[0]
+	var plan PlanResponse
+	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &plan); err != nil {
+		return nil, ToolCall{}, fmt.Errorf("openai: decode tool arguments: %w", err)
+	}
+
+	return &plan, ToolCall{
+		ID:        toolCall.ID,
+		Name:      toolCall.Function.Name,
+		Arguments: toolCall.Function.Arguments,
+	}, nil
+}
+
+func buildMessages(history []ChatMessage) []chatMessage {
+	messages := make([]chatMessage, 0, len(history))
+	for _, entry := range history {
+		msg := chatMessage{
+			Role:    string(entry.Role),
+			Content: entry.Content,
+		}
+		if entry.Role == RoleTool {
+			msg.Name = schema.ToolName
+			msg.ToolCallID = entry.ToolCallID
+		}
+		if len(entry.ToolCalls) > 0 {
+			calls := make([]assistantToolCall, 0, len(entry.ToolCalls))
+			for _, call := range entry.ToolCalls {
+				calls = append(calls, assistantToolCall{
+					ID:   call.ID,
+					Type: "function",
+					Function: assistantToolFunction{
+						Name:      call.Name,
+						Arguments: call.Arguments,
+					},
+				})
+			}
+			msg.ToolCalls = calls
+		}
+		messages = append(messages, msg)
+	}
+	return messages
+}
+
+type chatCompletionRequest struct {
+	Model      string              `json:"model"`
+	Messages   []chatMessage       `json:"messages"`
+	Tools      []toolSpecification `json:"tools"`
+	ToolChoice toolChoice          `json:"tool_choice"`
+}
+
+type chatMessage struct {
+	Role       string              `json:"role"`
+	Content    string              `json:"content,omitempty"`
+	Name       string              `json:"name,omitempty"`
+	ToolCallID string              `json:"tool_call_id,omitempty"`
+	ToolCalls  []assistantToolCall `json:"tool_calls,omitempty"`
+}
+
+type assistantToolCall struct {
+	ID       string                `json:"id"`
+	Type     string                `json:"type"`
+	Function assistantToolFunction `json:"function"`
+}
+
+type assistantToolFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type toolSpecification struct {
+	Type     string             `json:"type"`
+	Function functionDefinition `json:"function"`
+}
+
+type functionDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}
+
+type toolChoice struct {
+	Type     string              `json:"type"`
+	Function *toolChoiceFunction `json:"function,omitempty"`
+}
+
+type toolChoiceFunction struct {
+	Name string `json:"name"`
+}
+
+type chatCompletionResponse struct {
+	Choices []struct {
+		Message struct {
+			Role      string `json:"role"`
+			Content   string `json:"content"`
+			ToolCalls []struct {
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"message"`
+	} `json:"choices"`
+}

--- a/golang/internal/core/runtime/plan_manager.go
+++ b/golang/internal/core/runtime/plan_manager.go
@@ -1,0 +1,148 @@
+package runtime
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// PlanManager maintains the merged plan shared across passes.
+type PlanManager struct {
+	mu    sync.RWMutex
+	order []string
+	steps map[string]*PlanStep
+}
+
+// NewPlanManager constructs an empty plan manager.
+func NewPlanManager() *PlanManager {
+	return &PlanManager{
+		steps: make(map[string]*PlanStep),
+	}
+}
+
+// Replace swaps the current plan with the provided steps.
+func (pm *PlanManager) Replace(steps []PlanStep) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	pm.steps = make(map[string]*PlanStep, len(steps))
+	pm.order = pm.order[:0]
+	for _, step := range steps {
+		copied := step
+		pm.steps[step.ID] = &copied
+		pm.order = append(pm.order, step.ID)
+	}
+}
+
+// Snapshot returns a deep copy of the plan for external observers.
+func (pm *PlanManager) Snapshot() []PlanStep {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	result := make([]PlanStep, 0, len(pm.order))
+	for _, id := range pm.order {
+		if step, ok := pm.steps[id]; ok {
+			copied := *step
+			if step.WaitingForID != nil {
+				copied.WaitingForID = append([]string{}, step.WaitingForID...)
+			}
+			if step.Observation != nil {
+				obsCopy := *step.Observation
+				if step.Observation.ObservationForLLM != nil {
+					payloadCopy := *step.Observation.ObservationForLLM
+					if payloadCopy.Plan != nil {
+						payloadCopy.Plan = append([]PlanStep{}, payloadCopy.Plan...)
+					}
+					obsCopy.ObservationForLLM = &payloadCopy
+				}
+				copied.Observation = &obsCopy
+			}
+			result = append(result, copied)
+		}
+	}
+	return result
+}
+
+// Ready returns the next executable plan step if all dependencies have completed.
+func (pm *PlanManager) Ready() (*PlanStep, bool) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	for _, id := range pm.order {
+		step := pm.steps[id]
+		if step == nil || step.Status != PlanPending {
+			continue
+		}
+		ready := true
+		for _, waitID := range step.WaitingForID {
+			dep := pm.steps[waitID]
+			if dep == nil {
+				continue
+			}
+			if dep.Status != PlanCompleted {
+				ready = false
+				break
+			}
+		}
+		if ready {
+			copied := *step
+			return &copied, true
+		}
+	}
+	return nil, false
+}
+
+// UpdateStatus updates the step status while preserving metadata.
+func (pm *PlanManager) UpdateStatus(id string, status PlanStatus, observation *PlanObservation) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	step, ok := pm.steps[id]
+	if !ok {
+		return errors.New("plan: unknown step id")
+	}
+	step.Status = status
+	if observation != nil {
+		step.Observation = observation
+	}
+	return nil
+}
+
+// HasPending reports whether any step is still pending.
+func (pm *PlanManager) HasPending() bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	for _, step := range pm.steps {
+		if step != nil && step.Status == PlanPending {
+			return true
+		}
+	}
+	return false
+}
+
+// Completed reports whether every step finished successfully.
+func (pm *PlanManager) Completed() bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	for _, step := range pm.steps {
+		if step == nil {
+			continue
+		}
+		if step.Status != PlanCompleted {
+			return false
+		}
+	}
+	return len(pm.steps) > 0
+}
+
+// SortOrder returns the deterministic step order for reporting.
+func (pm *PlanManager) SortOrder() []PlanStep {
+	snapshot := pm.Snapshot()
+	sort.SliceStable(snapshot, func(i, j int) bool {
+		return strings.Compare(snapshot[i].ID, snapshot[j].ID) < 0
+	})
+	return snapshot
+}

--- a/golang/internal/core/runtime/runtime.go
+++ b/golang/internal/core/runtime/runtime.go
@@ -1,0 +1,297 @@
+package runtime
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// RuntimeOptions control how the Go runtime mirrors the TypeScript agent loop.
+type RuntimeOptions struct {
+	APIKey                   string
+	Model                    string
+	SystemPrompt             string
+	SystemPromptAugmentation string
+	AutoApprove              bool
+	NoHuman                  bool
+	PlanReminderMessage      string
+	NoHumanAutoMessage       string
+	UserPrompt               string
+	Input                    io.Reader
+	Output                   io.Writer
+	Clock                    func() time.Time
+}
+
+// Runtime orchestrates the conversation with OpenAI and shell command execution.
+type Runtime struct {
+	options      RuntimeOptions
+	client       *OpenAIClient
+	planManager  *PlanManager
+	executor     *CommandExecutor
+	history      []ChatMessage
+	lastToolCall ToolCall
+	reader       *bufio.Reader
+	writer       io.Writer
+}
+
+// NewRuntime wires together the supporting services based on the provided options.
+func NewRuntime(opts RuntimeOptions) (*Runtime, error) {
+	options := opts
+	if options.SystemPrompt == "" {
+		options.SystemPrompt = "You are OpenAgent running inside a Go console application."
+	}
+	if options.PlanReminderMessage == "" {
+		options.PlanReminderMessage = DefaultPlanReminder
+	}
+	if options.NoHumanAutoMessage == "" {
+		options.NoHumanAutoMessage = DefaultNoHumanAutoMessage
+	}
+	if options.UserPrompt == "" {
+		options.UserPrompt = "\n▷ "
+	}
+	if options.Input == nil {
+		options.Input = os.Stdin
+	}
+	if options.Output == nil {
+		options.Output = os.Stdout
+	}
+	if options.Clock == nil {
+		options.Clock = time.Now
+	}
+
+	client, err := NewOpenAIClient(options.APIKey, options.Model)
+	if err != nil {
+		return nil, err
+	}
+
+	runtime := &Runtime{
+		options:     options,
+		client:      client,
+		planManager: NewPlanManager(),
+		executor:    NewCommandExecutor(),
+		history:     make([]ChatMessage, 0, 32),
+	}
+	return runtime, nil
+}
+
+// Run starts the interactive loop until EOF or an explicit exit command.
+func (rt *Runtime) Run(ctx context.Context) error {
+	rt.reader = bufio.NewReader(rt.options.Input)
+	rt.writer = rt.options.Output
+
+	systemPrompt := rt.options.SystemPrompt
+	if rt.options.SystemPromptAugmentation != "" {
+		systemPrompt = systemPrompt + "\n\n" + rt.options.SystemPromptAugmentation
+	}
+	rt.appendMessage(ChatMessage{Role: RoleSystem, Content: systemPrompt})
+
+	fmt.Fprintln(rt.writer, "OpenAgent Go runtime ready. Type /exit to quit, /plan to inspect the current plan.")
+
+	for {
+		executed, err := rt.executePlanIfReady(ctx)
+		if err != nil {
+			return err
+		}
+		if executed {
+			continue
+		}
+
+		if rt.options.NoHuman {
+			message := rt.options.NoHumanAutoMessage
+			if rt.planManager.HasPending() {
+				message = rt.options.PlanReminderMessage
+			}
+			if last := rt.lastUserMessage(); last != nil && last.Content == message {
+				message = ""
+			}
+			if err := rt.queryAssistant(ctx, message); err != nil {
+				return err
+			}
+			continue
+		}
+
+		fmt.Fprint(rt.writer, rt.options.UserPrompt)
+		line, err := rt.reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				fmt.Fprintln(rt.writer, "\nGoodbye.")
+				return nil
+			}
+			return fmt.Errorf("runtime: read input: %w", err)
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.EqualFold(line, "/exit") {
+			fmt.Fprintln(rt.writer, "Exiting on request.")
+			return nil
+		}
+		if strings.EqualFold(line, "/plan") {
+			rt.printPlan()
+			continue
+		}
+		if strings.EqualFold(line, "/auto") {
+			rt.options.AutoApprove = !rt.options.AutoApprove
+			state := "disabled"
+			if rt.options.AutoApprove {
+				state = "enabled"
+			}
+			fmt.Fprintf(rt.writer, "Auto-approve %s.\n", state)
+			continue
+		}
+
+		rt.appendMessage(ChatMessage{Role: RoleUser, Content: line})
+		if err := rt.queryAssistant(ctx, ""); err != nil {
+			return err
+		}
+	}
+}
+
+func (rt *Runtime) executePlanIfReady(ctx context.Context) (bool, error) {
+	step, ok := rt.planManager.Ready()
+	if !ok {
+		return false, nil
+	}
+
+	if !rt.options.AutoApprove && !rt.options.NoHuman {
+		fmt.Fprintf(rt.writer, "\nPlan step %s is ready:\n  %s\n  Command: %s\nExecute? [y/N]: ", step.ID, step.Title, step.Command.Run)
+		answer, err := rt.reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return false, err
+			}
+			return false, fmt.Errorf("runtime: read approval: %w", err)
+		}
+		answer = strings.TrimSpace(strings.ToLower(answer))
+		if answer != "y" && answer != "yes" {
+			fmt.Fprintf(rt.writer, "Skipped plan step %s.\n", step.ID)
+			return true, nil
+		}
+	} else if !rt.options.AutoApprove && rt.options.NoHuman {
+		fmt.Fprintf(rt.writer, "\nNo human available to approve step %s. Requesting updated plan.\n", step.ID)
+		if err := rt.queryAssistant(ctx, rt.options.PlanReminderMessage); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
+	fmt.Fprintf(rt.writer, "\nExecuting plan step %s: %s\nCommand: %s\n", step.ID, step.Title, step.Command.Run)
+	observation, err := rt.executor.Execute(ctx, step)
+	status := PlanCompleted
+	if err != nil {
+		status = PlanFailed
+		fmt.Fprintf(rt.writer, "Command error: %v\n", err)
+	} else {
+		fmt.Fprintln(rt.writer, "Command completed successfully.")
+	}
+
+	if updateErr := rt.planManager.UpdateStatus(step.ID, status, &PlanObservation{ObservationForLLM: &observation}); updateErr != nil {
+		return true, updateErr
+	}
+
+	if rt.lastToolCall.ID != "" {
+		payload, encodeErr := BuildToolMessage(observation)
+		if encodeErr == nil {
+			rt.appendMessage(ChatMessage{
+				Role:       RoleTool,
+				Content:    payload,
+				ToolCallID: rt.lastToolCall.ID,
+			})
+		} else {
+			summary := rt.summarizeObservation(step.ID, observation, encodeErr)
+			rt.appendMessage(ChatMessage{Role: RoleUser, Content: summary})
+		}
+	} else {
+		summary := rt.summarizeObservation(step.ID, observation, nil)
+		rt.appendMessage(ChatMessage{Role: RoleUser, Content: summary})
+	}
+
+	if err := rt.queryAssistant(ctx, ""); err != nil {
+		return true, err
+	}
+
+	return true, nil
+}
+
+func (rt *Runtime) queryAssistant(ctx context.Context, userMessage string) error {
+	if userMessage != "" {
+		rt.appendMessage(ChatMessage{Role: RoleUser, Content: userMessage})
+	}
+	plan, toolCall, err := rt.client.RequestPlan(ctx, rt.history)
+	if err != nil {
+		return err
+	}
+	rt.lastToolCall = toolCall
+	rt.appendMessage(ChatMessage{
+		Role:      RoleAssistant,
+		Content:   plan.Message,
+		ToolCalls: []ToolCall{toolCall},
+	})
+	rt.planManager.Replace(plan.Plan)
+
+	fmt.Fprintf(rt.writer, "\nAssistant:\n%s\n", plan.Message)
+	if len(plan.Plan) > 0 {
+		fmt.Fprintln(rt.writer, "Current plan:")
+		for _, step := range plan.Plan {
+			fmt.Fprintf(rt.writer, "  [%s] %-9s %s\n", step.ID, step.Status, step.Title)
+		}
+	} else {
+		fmt.Fprintln(rt.writer, "Plan is empty.")
+	}
+	return nil
+}
+
+func (rt *Runtime) summarizeObservation(id string, obs PlanObservationPayload, encodeErr error) string {
+	summary := map[string]any{
+		"step":      id,
+		"stdout":    obs.Stdout,
+		"stderr":    obs.Stderr,
+		"truncated": obs.Truncated,
+	}
+	if obs.ExitCode != nil {
+		summary["exit_code"] = *obs.ExitCode
+	}
+	if encodeErr != nil {
+		summary["encoding_error"] = encodeErr.Error()
+	}
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("step %s observation: exit=%v", id, obs.ExitCode)
+	}
+	return string(data)
+}
+
+func (rt *Runtime) printPlan() {
+	snapshot := rt.planManager.SortOrder()
+	if len(snapshot) == 0 {
+		fmt.Fprintln(rt.writer, "No plan available.")
+		return
+	}
+	fmt.Fprintln(rt.writer, "Plan snapshot:")
+	for _, step := range snapshot {
+		fmt.Fprintf(rt.writer, "  [%s] %-9s %s\n", step.ID, step.Status, step.Title)
+	}
+}
+
+func (rt *Runtime) appendMessage(msg ChatMessage) {
+	if msg.Timestamp.IsZero() {
+		msg.Timestamp = rt.options.Clock()
+	}
+	rt.history = append(rt.history, msg)
+}
+
+func (rt *Runtime) lastUserMessage() *ChatMessage {
+	for i := len(rt.history) - 1; i >= 0; i-- {
+		if rt.history[i].Role == RoleUser {
+			return &rt.history[i]
+		}
+	}
+	return nil
+}

--- a/golang/internal/core/runtime/types.go
+++ b/golang/internal/core/runtime/types.go
@@ -1,0 +1,89 @@
+package runtime
+
+import "time"
+
+// MessageRole enumerates the chat roles supported by the runtime.
+type MessageRole string
+
+const (
+	RoleSystem    MessageRole = "system"
+	RoleUser      MessageRole = "user"
+	RoleAssistant MessageRole = "assistant"
+	RoleTool      MessageRole = "tool"
+)
+
+// ChatMessage stores a single message exchanged with OpenAI.
+type ChatMessage struct {
+	Role       MessageRole
+	Content    string
+	ToolCallID string
+	Name       string
+	Timestamp  time.Time
+	ToolCalls  []ToolCall
+}
+
+// ToolCall stores metadata for an assistant tool invocation.
+type ToolCall struct {
+	ID        string
+	Name      string
+	Arguments string
+}
+
+// CommandDraft replicates the shell command contract embedded in the plan schema.
+type CommandDraft struct {
+	Reason      string `json:"reason"`
+	Shell       string `json:"shell"`
+	Run         string `json:"run"`
+	Cwd         string `json:"cwd"`
+	TimeoutSec  int    `json:"timeout_sec"`
+	FilterRegex string `json:"filter_regex"`
+	TailLines   int    `json:"tail_lines"`
+	MaxBytes    int    `json:"max_bytes"`
+}
+
+// PlanStatus represents execution status for a plan step.
+type PlanStatus string
+
+const (
+	PlanPending   PlanStatus = "pending"
+	PlanCompleted PlanStatus = "completed"
+	PlanFailed    PlanStatus = "failed"
+	PlanAbandoned PlanStatus = "abandoned"
+)
+
+// PlanObservationPayload mirrors the JSON payload forwarded back to the model.
+type PlanObservationPayload struct {
+	Plan                    []PlanStep `json:"plan,omitempty"`
+	Stdout                  string     `json:"stdout,omitempty"`
+	Stderr                  string     `json:"stderr,omitempty"`
+	Truncated               bool       `json:"truncated,omitempty"`
+	ExitCode                *int       `json:"exit_code,omitempty"`
+	JSONParseError          bool       `json:"json_parse_error,omitempty"`
+	SchemaValidationError   bool       `json:"schema_validation_error,omitempty"`
+	ResponseValidationError bool       `json:"response_validation_error,omitempty"`
+	CanceledByHuman         bool       `json:"canceled_by_human,omitempty"`
+	OperationCanceled       bool       `json:"operation_canceled,omitempty"`
+	Summary                 string     `json:"summary,omitempty"`
+	Details                 string     `json:"details,omitempty"`
+}
+
+// PlanObservation bundles the payload with optional metadata.
+type PlanObservation struct {
+	ObservationForLLM *PlanObservationPayload `json:"observation_for_llm,omitempty"`
+}
+
+// PlanStep describes an individual plan entry from OpenAI.
+type PlanStep struct {
+	ID           string           `json:"id"`
+	Title        string           `json:"title"`
+	Status       PlanStatus       `json:"status"`
+	WaitingForID []string         `json:"waitingForId"`
+	Command      CommandDraft     `json:"command"`
+	Observation  *PlanObservation `json:"observation,omitempty"`
+}
+
+// PlanResponse captures the structured assistant output.
+type PlanResponse struct {
+	Message string     `json:"message"`
+	Plan    []PlanStep `json:"plan"`
+}

--- a/golang/internal/core/schema/schema.go
+++ b/golang/internal/core/schema/schema.go
@@ -1,0 +1,145 @@
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ToolName is the canonical identifier shared with the assistant runtime.
+const ToolName = "open-agent"
+
+// toolDescription mirrors the TypeScript tool description so prompts stay aligned.
+const toolDescription = "Return the response envelope that matches the OpenAgent protocol (message, plan, and command fields)."
+
+// planResponseSchemaJSON copies the Draft-07 JSON schema used by the TypeScript runtime.
+// The schema is stored as raw JSON so we can provide it to OpenAI without translation losses.
+const planResponseSchemaJSON = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["message", "plan"],
+  "properties": {
+    "message": {
+      "type": "string",
+      "description": "Markdown formatted message to the user."
+    },
+    "plan": {
+      "type": "array",
+      "description": "a DAG (Directed Acyclic Graph) of tasks to execute, each task executes exactly 1 command, each task can depend on 0 or more other tasks to complete before executing. User goals should be the last task to execute in the chain of task. e.g 'I want to create a guess a number game in js', then 'game created' is the end node in the graph. The DAG is designed to do groundwork first, creating files, install packages etc. and to validate, run tests etc as end nodes.",
+      "items": {
+        "type": "object",
+        "description": "a single task in the DAG plan, represents both the task and the shell command to execute",
+        "additionalProperties": false,
+        "required": ["id", "title", "status", "waitingForId", "command"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Random ID assigned by AI."
+          },
+          "title": {
+            "type": "string",
+            "description": "Human readable summary of the plan step."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "completed", "failed", "abandoned"],
+            "description": "Current execution status for the plan step. \"failed\" tasks, should be \"abandoned\" by the Assistant other plan steps that are waiting for a failed or abandoned step. should now replace that 'id' in their waitingForId array. e.g. A is waiting for B, B fails, B should now be abandoned, A should now wait for new task C, where C now can perform another command and try something else to not fail."
+          },
+          "waitingForId": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": [],
+            "description": "IDs this task has to wait for before it can be executed (dependencies)."
+          },
+          "command": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Next tool invocation to execute for this plan step. This command should complete the task if successful.",
+            "required": [
+              "reason",
+              "shell",
+              "run",
+              "cwd",
+              "timeout_sec",
+              "filter_regex",
+              "tail_lines",
+              "max_bytes"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "default": "",
+                "description": "Explain why this shell command is required for the plan step. If only shell or run is provided, justify the omission."
+              },
+              "shell": {
+                "type": "string",
+                "description": "Shell executable to launch when running commands. May only contain value if \"run\" contains an actual command to run."
+              },
+              "run": {
+                "type": "string",
+                "description": "Command string to execute in the provided shell. Must be set if \"shell\" has a value; may NOT be set if \"shell\" has no value."
+              },
+              "cwd": {
+                "type": "string",
+                "default": "",
+                "description": "Working directory for shell execution."
+              },
+              "timeout_sec": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 60,
+                "description": "Timeout guard for long-running commands (seconds)."
+              },
+              "filter_regex": {
+                "type": "string",
+                "default": "",
+                "description": "Regex used to filter command output (empty for none)."
+              },
+              "tail_lines": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 200,
+                "description": "Number of trailing lines to return from output (0 disables the limit)."
+              },
+              "max_bytes": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 16384,
+                "description": "Maximum number of bytes to include from stdout/stderr (defaults to ~200 lines at 16 KiB)."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+// PlanResponseSchema returns the parsed JSON schema so callers can embed it in OpenAI requests.
+func PlanResponseSchema() (map[string]any, error) {
+	var value map[string]any
+	if err := json.Unmarshal([]byte(planResponseSchemaJSON), &value); err != nil {
+		return nil, fmt.Errorf("schema: decode plan schema: %w", err)
+	}
+	return value, nil
+}
+
+// ToolDefinition describes the single structured tool exposed to the model.
+type ToolDefinition struct {
+	Name        string
+	Description string
+	Parameters  map[string]any
+}
+
+// Definition returns the canonical tool metadata used across the runtime.
+func Definition() (ToolDefinition, error) {
+	schema, err := PlanResponseSchema()
+	if err != nil {
+		return ToolDefinition{}, err
+	}
+	return ToolDefinition{
+		Name:        ToolName,
+		Description: toolDescription,
+		Parameters:  schema,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- add a new `golang` workspace with a console runtime that mirrors the TypeScript agent loop
- embed the canonical OpenAgent plan schema and implement plan management, command execution, and OpenAI client wrappers in Go
- document the new workspace in the root context index

## Testing
- not run (environment limitations fetching Go modules)

------
https://chatgpt.com/codex/tasks/task_e_68fbcf52f9a08328b1652ee0a2732790